### PR TITLE
[BST-8] error: unsolved filtering 문제 해결

### DIFF
--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/MockGroupRepository.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/MockGroupRepository.java
@@ -37,6 +37,7 @@ public class MockGroupRepository implements GroupRepository{
     public List<Long> findUsersSolvedProblems(Long groupId) {
         return MOCK_EACH_USERS_SOLVED_PROBLEMS.stream()
                 .map(UserSolvedDto::getProblemId)
+                .distinct()
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/ProblemFetchServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/ProblemFetchServiceImpl.java
@@ -27,9 +27,11 @@ public class ProblemFetchServiceImpl implements ProblemFetchService{
     public List<ProblemDto> fetchBaseProblems(Long groupId, Boolean unsolved) {
         if (Boolean.TRUE.equals(unsolved)) {
             // 그룹에서 해결된 문제 ID 가져오기
-            List<Long> solvedProblemIds = groupRepository.findGroupSolvedProblems(groupId);
+            //List<Long> solvedProblemIds = groupRepository.findGroupSolvedProblems(groupId);
             // 모든 문제를 가져옴
             List<ProblemDto> allProblems = problemRepository.findAll();
+
+            List<Long> solvedProblemIds = groupRepository.findUsersSolvedProblems(groupId);
 
             System.out.println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
             System.out.println("test unsolved problems");


### PR DESCRIPTION
이슈번호: https://github.com/cheonggangsan/BlueStrongMountain_backend/issues/8
unsolved tag 설정 시 그룹에 속한 사용자들의 해결한 문제들을 가져와 처리해야 하는데 기존 로직은 그룹자체에서 해결한 문제를 가지고 처리하여 논리상 문제가 있음 이를 해결함