### PR TITLE
[BST-4] Board 기본 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -677,8 +677,6 @@ pyrightconfig.json
 # TODO: where does this rule come from?
 docs/_book
 
-# TODO: where does this rule come from?
-test/
 
 ### Vuejs ###
 # Recommended template: Node.gitignore

--- a/src/main/java/com/ssafy/BlueStrongMountain/controller/BoardController.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/controller/BoardController.java
@@ -1,0 +1,91 @@
+package com.ssafy.BlueStrongMountain.controller;
+
+import com.ssafy.BlueStrongMountain.dto.BoardCreateRequest;
+import com.ssafy.BlueStrongMountain.dto.BoardSearchCondition;
+import com.ssafy.BlueStrongMountain.dto.BoardUpdateRequest;
+import com.ssafy.BlueStrongMountain.dto.BoardDetailResponse;
+import com.ssafy.BlueStrongMountain.dto.BoardResponse;
+import com.ssafy.BlueStrongMountain.service.BoardService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/groups/{groupId}/boards")
+public class BoardController {
+
+    private final BoardService boardService;
+
+    public BoardController(BoardService boardService) {
+        this.boardService = boardService;
+    }
+
+    /**
+     * POST /api/v1/groups/{groupId}/boards
+     * 보드 생성
+     */
+    @PostMapping
+    public Long createBoard(
+            @PathVariable Long groupId,
+            @RequestParam Long requesterId,
+            @RequestBody BoardCreateRequest request
+    ) {
+        //return boardService.createBoard(requesterId, groupId, request);
+        Long tmp = boardService.createBoard(requesterId, groupId, request);
+        System.out.println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+        System.out.println(tmp);//test
+
+        return tmp;
+    }
+
+    /**
+     * GET /api/v1/groups/{groupId}/boards
+     * 목록 조회 (검색 조건 포함)
+     */
+    @GetMapping
+    public List<BoardResponse> getBoards(
+            @PathVariable Long groupId,
+            @ModelAttribute BoardSearchCondition condition
+    ) {
+        return boardService.getBoards(groupId, condition);
+    }
+
+    /**
+     * GET /api/v1/groups/{groupId}/boards/{boardId}
+     * 단건 조회
+     */
+    @GetMapping("/{boardId}")
+    public BoardDetailResponse getBoard(
+            @PathVariable Long groupId,
+            @PathVariable Long boardId
+    ) {
+        return boardService.getBoard(groupId, boardId);
+    }
+
+    /**
+     * PATCH /api/v1/groups/{groupId}/boards/{boardId}
+     * 보드 수정
+     */
+    @PatchMapping("/{boardId}")
+    public void updateBoard(
+            @PathVariable Long groupId,
+            @PathVariable Long boardId,
+            @RequestParam Long requesterId,
+            @RequestBody BoardUpdateRequest request
+    ) {
+        boardService.updateBoard(requesterId, groupId, boardId, request);
+    }
+
+    /**
+     * DELETE /api/v1/groups/{groupId}/boards/{boardId}
+     * 보드 삭제
+     */
+    @DeleteMapping("/{boardId}")
+    public void deleteBoard(
+            @PathVariable Long groupId,
+            @PathVariable Long boardId,
+            @RequestParam Long requesterId
+    ) {
+        boardService.deleteBoard(requesterId, groupId, boardId);
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/domain/Board.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/domain/Board.java
@@ -1,0 +1,120 @@
+package com.ssafy.BlueStrongMountain.domain;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public final class Board {
+
+    private final Long id;
+    private final Long groupId;
+    private final Long writerId;
+    private final String title;
+    private final String content;
+    private final LocalDateTime startTime;
+    private final LocalDateTime endTime;
+    private final Integer viewCount;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    // 생성자: 생성 시점에 모든 필드가 할당됨 (update 없음)
+    public Board(Long id,
+                 Long groupId,
+                 Long writerId,
+                 String title,
+                 String content,
+                 LocalDateTime startTime,
+                 LocalDateTime endTime,
+                 Integer viewCount,
+                 LocalDateTime createdAt,
+                 LocalDateTime updatedAt) {
+
+        this.id = id;
+        this.groupId = groupId;
+        this.writerId = writerId;
+        this.title = title;
+        this.content = content;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.viewCount = viewCount;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    // 최초 생성 시 사용할 static factory
+    public static Board create(Long groupId,
+                               Long writerId,
+                               String title,
+                               String content,
+                               LocalDateTime endTime) {
+
+        LocalDateTime now = LocalDateTime.now();
+
+        return new Board(
+                null,
+                groupId,
+                writerId,
+                title,
+                content,
+                now,
+                endTime,
+                0,
+                now,
+                null
+        );
+    }
+
+    // Repository에서 ID 할당할 때 새 객체를 만드는 방식
+    public Board assignId(Long newId) {
+        return new Board(
+                newId,
+                this.groupId,
+                this.writerId,
+                this.title,
+                this.content,
+                this.startTime,
+                this.endTime,
+                this.viewCount,
+                this.createdAt,
+                this.updatedAt
+        );
+    }
+
+    // 수정: 불변 객체 → 수정 시 새 객체를 리턴하는 방식
+    public Board update(String title, LocalDateTime endTime, String content) {
+        return new Board(
+                this.id,
+                this.groupId,
+                this.writerId,
+                title,
+                content,
+                this.startTime,
+                endTime,
+                this.viewCount,
+                this.createdAt,
+                LocalDateTime.now()
+        );
+    }
+
+    // 조회수 증가도 새 객체로
+    public Board increaseViewCount() {
+        return new Board(
+                this.id,
+                this.groupId,
+                this.writerId,
+                this.title,
+                this.content,
+                this.startTime,
+                this.endTime,
+                this.viewCount + 1,
+                this.createdAt,
+                this.updatedAt
+        );
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/domain/BoardProblem.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/domain/BoardProblem.java
@@ -1,0 +1,50 @@
+package com.ssafy.BlueStrongMountain.domain;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class BoardProblem {
+
+    private final Long id;
+    private final Long boardId;
+    private final Long problemId;
+    private final Integer orderIndex;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    private BoardProblem(Long id, Long boardId, Long problemId, Integer orderIndex,
+                         LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.boardId = boardId;
+        this.problemId = problemId;
+        this.orderIndex = orderIndex;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public static BoardProblem create(Long boardId, Long problemId, Integer orderIndex) {
+        return new BoardProblem(
+                null,
+                boardId,
+                problemId,
+                orderIndex,
+                LocalDateTime.now(),
+                null
+        );
+    }
+
+    public BoardProblem assignId(Long id) {
+        return new BoardProblem(
+                id,
+                this.boardId,
+                this.problemId,
+                this.orderIndex,
+                this.createdAt,
+                this.updatedAt
+        );
+    }
+
+}
+

--- a/src/main/java/com/ssafy/BlueStrongMountain/domain/BoardUserProgress.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/domain/BoardUserProgress.java
@@ -1,0 +1,36 @@
+package com.ssafy.BlueStrongMountain.domain;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class BoardUserProgress {
+
+    public enum Status {
+        PENDING, SOLVED
+    }
+
+    private Long id;
+    private Long boardId;
+    private Long userId;
+    private Long problemId;
+    private Status status;
+    private LocalDateTime solvedAt;
+
+    public BoardUserProgress(Long boardId, Long userId, Long problemId) {
+        this.boardId = boardId;
+        this.userId = userId;
+        this.problemId = problemId;
+        this.status = Status.PENDING;
+    }
+
+    public void assignId(Long id) {
+        this.id = id;
+    }
+
+    public void markSolved() {
+        this.status = Status.SOLVED;
+        this.solvedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/BoardCreateRequest.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/BoardCreateRequest.java
@@ -1,0 +1,15 @@
+package com.ssafy.BlueStrongMountain.dto;
+
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@ToString
+public class BoardCreateRequest {
+    private String title;
+    private LocalDateTime endTime;
+    private List<Long> problemIds;
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/BoardDetailResponse.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/BoardDetailResponse.java
@@ -1,0 +1,27 @@
+package com.ssafy.BlueStrongMountain.dto;
+
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@ToString
+public class BoardDetailResponse {
+
+    private Long boardId;
+    private String title;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+    private List<Long> problemIds;
+
+    public BoardDetailResponse(Long boardId, String title, LocalDateTime startTime,
+                               LocalDateTime endTime, List<Long> problemIds) {
+        this.boardId = boardId;
+        this.title = title;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.problemIds = problemIds;
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/BoardResponse.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/BoardResponse.java
@@ -1,0 +1,20 @@
+package com.ssafy.BlueStrongMountain.dto;
+
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+public class BoardResponse {
+    private Long boardId;
+    private String title;
+    private LocalDateTime endTime;
+
+    public BoardResponse(Long boardId, String title, LocalDateTime endTime) {
+        this.boardId = boardId;
+        this.title = title;
+        this.endTime = endTime;
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/BoardSearchCondition.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/BoardSearchCondition.java
@@ -1,0 +1,15 @@
+package com.ssafy.BlueStrongMountain.dto;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class BoardSearchCondition {
+    private String title;
+    private String status; // ONGOING, FINISHED
+    private Integer page;
+    private Integer size;
+    private String sort;
+
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/BoardUpdateRequest.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/BoardUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.ssafy.BlueStrongMountain.dto;
+
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@ToString
+public class BoardUpdateRequest {
+    private String title;
+    private LocalDateTime endTime;
+    private List<Long> problemIds;
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/BoardProblemRepository.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/BoardProblemRepository.java
@@ -1,0 +1,11 @@
+package com.ssafy.BlueStrongMountain.repository;
+
+import com.ssafy.BlueStrongMountain.domain.BoardProblem;
+
+import java.util.List;
+
+public interface BoardProblemRepository {
+    void deleteByBoardId(Long boardId);
+    void saveAll(List<BoardProblem> problems);
+    List<BoardProblem> findByBoardId(Long boardId);
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/BoardRepository.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/BoardRepository.java
@@ -1,8 +1,13 @@
 package com.ssafy.BlueStrongMountain.repository;
 
+import com.ssafy.BlueStrongMountain.domain.Board;
+
 import java.util.List;
+import java.util.Optional;
 
 public interface BoardRepository {
-    List<Long> findBoardIdsByGroupId(Long groupId);
-    List<Long> findProblemIdsByBoards(List<Long> boardIds);
+    Board save(Board board);
+    Optional<Board> findById(Long boardId);
+    List<Board> findByGroupId(Long groupId);
+    void delete(Long boardId);
 }

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/InMemoryBoardProblemRepository.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/InMemoryBoardProblemRepository.java
@@ -1,0 +1,62 @@
+package com.ssafy.BlueStrongMountain.repository;
+
+import com.ssafy.BlueStrongMountain.domain.BoardProblem;
+import com.ssafy.BlueStrongMountain.repository.BoardProblemRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Repository
+public class InMemoryBoardProblemRepository implements BoardProblemRepository {
+    // id 기반 저장소
+    private final Map<Long, BoardProblem> store = new HashMap<>();
+    // 보드 단위 조회 인덱스
+    private final Map<Long, List<Long>> boardIndex = new HashMap<>();
+    private final AtomicLong sequence = new AtomicLong(1);
+    @Override
+    public void deleteByBoardId(Long boardId) {
+
+        List<Long> problemIds = boardIndex.getOrDefault(boardId, new ArrayList<>());
+
+        // id 리스트 삭제
+        for (Long id : problemIds) {
+            store.remove(id);
+        }
+
+        // 인덱스 삭제
+        boardIndex.remove(boardId);
+    }
+
+    @Override
+    public void saveAll(List<BoardProblem> problems) {
+
+        for (BoardProblem p : problems) {
+            Long newId = sequence.getAndIncrement();
+
+            // Immutable 객체이므로 assignId로 새 객체 생성
+            BoardProblem saved = p.assignId(newId);
+            store.put(newId, saved);
+
+            // boardId 인덱스 갱신
+            boardIndex.computeIfAbsent(saved.getBoardId(), k -> new ArrayList<>())
+                    .add(newId);
+        }
+    }
+
+    @Override
+    public List<BoardProblem> findByBoardId(Long boardId) {
+
+        List<Long> ids = boardIndex.getOrDefault(boardId, Collections.emptyList());
+
+        List<BoardProblem> result = new ArrayList<>();
+        for (Long id : ids) {
+            BoardProblem bp = store.get(id);
+            if (bp != null) {
+                result.add(bp);
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/InMemoryBoardRepository.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/InMemoryBoardRepository.java
@@ -1,0 +1,42 @@
+package com.ssafy.BlueStrongMountain.repository;
+
+import com.ssafy.BlueStrongMountain.domain.Board;
+import org.springframework.stereotype.Repository;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Repository
+public class InMemoryBoardRepository implements BoardRepository{
+    private final Map<Long, Board> store = new HashMap<>();
+    private final AtomicLong sequence = new AtomicLong(1);
+
+    @Override
+    public Board save(Board board) {
+        Long id = board.getId() == null ? sequence.incrementAndGet() : board.getId();
+        Board toSave = board.getId() == null ? board.assignId(id) : board;
+        store.put(id, toSave);
+        return toSave;
+    }
+
+    @Override
+    public Optional<Board> findById(Long boardId) {
+        return Optional.ofNullable(store.get(boardId));
+    }
+
+    @Override
+    public List<Board> findByGroupId(Long groupId) {
+        List<Board> result = new ArrayList<>();
+        for (Board board : store.values()) {
+            if (board.getGroupId().equals(groupId)) {
+                result.add(board);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public void delete(Long boardId) {
+        store.remove(boardId);
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/BoardService.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/BoardService.java
@@ -1,0 +1,13 @@
+package com.ssafy.BlueStrongMountain.service;
+
+import com.ssafy.BlueStrongMountain.dto.*;
+
+import java.util.List;
+
+public interface BoardService {
+    Long createBoard(Long requesterId, Long groupId, BoardCreateRequest request);
+    List<BoardResponse> getBoards(Long groupId, BoardSearchCondition condition);
+    BoardDetailResponse getBoard(Long groupId, Long boardId);
+    void updateBoard(Long requesterId, Long groupId, Long boardId, BoardUpdateRequest request);
+    void deleteBoard(Long requesterId, Long groupId, Long boardId);
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/BoardServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/BoardServiceImpl.java
@@ -1,0 +1,115 @@
+package com.ssafy.BlueStrongMountain.service;
+
+import com.ssafy.BlueStrongMountain.domain.Board;
+import com.ssafy.BlueStrongMountain.domain.BoardProblem;
+import com.ssafy.BlueStrongMountain.dto.*;
+import com.ssafy.BlueStrongMountain.repository.BoardProblemRepository;
+import com.ssafy.BlueStrongMountain.repository.BoardRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class BoardServiceImpl implements BoardService{
+    private final BoardRepository boardRepository;
+    private final BoardProblemRepository boardProblemRepository;
+
+    public BoardServiceImpl(BoardRepository boardRepository,
+                            BoardProblemRepository boardProblemRepository) {
+        this.boardRepository = boardRepository;
+        this.boardProblemRepository = boardProblemRepository;
+    }
+    @Override
+    public Long createBoard(Long requesterId, Long groupId, BoardCreateRequest request) {
+
+        Board created = Board.create(
+                groupId,
+                requesterId,
+                request.getTitle(),
+                null,                              // content (현재 기능에서는 없음)
+                request.getEndTime()
+        );
+
+        // Repository에서 ID 부여 (immutable 객체라 새 객체 생성)
+        Board saved = boardRepository.save(created);
+
+        // 문제 매핑 저장
+        List<BoardProblem> problems = new ArrayList<>();
+        int order = 0;
+        for (Long pid : request.getProblemIds()) {
+            problems.add(BoardProblem.create(saved.getId(), pid, order++));
+        }
+
+        boardProblemRepository.saveAll(problems);
+
+        return saved.getId();
+    }
+
+    @Override
+    public List<BoardResponse> getBoards(Long groupId, BoardSearchCondition condition) {
+        List<Board> boards = boardRepository.findByGroupId(groupId);
+
+        // (검색 조건은 이후 QueryDSL 또는 필터 로직 추가)
+        return boards.stream()
+                .map(b -> new BoardResponse(b.getId(), b.getTitle(), b.getEndTime()))
+                .collect(Collectors.toList());
+    }
+    @Override
+    public BoardDetailResponse getBoard(Long groupId, Long boardId) {
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new RuntimeException("Board not found"));
+
+        List<Long> problemIds = boardProblemRepository.findByBoardId(boardId)
+                .stream()
+                .map(BoardProblem::getProblemId)
+                .toList();
+        // (검색 조건은 이후 QueryDSL 또는 필터 로직 추가)
+        return new BoardDetailResponse(
+                board.getId(),
+                board.getTitle(),
+                board.getStartTime(),
+                board.getEndTime(),
+                problemIds
+        );
+    }
+
+    @Override
+    public void updateBoard(Long requesterId, Long groupId, Long boardId, BoardUpdateRequest request) {
+        Board old = boardRepository.findById(boardId)
+                .orElseThrow(() -> new RuntimeException("Board not found"));
+
+        if (LocalDateTime.now().isAfter(old.getEndTime())) {
+            throw new RuntimeException("Deadline passed. Cannot update.");
+        }
+
+        // Immutable → 수정된 새 객체를 생성
+        Board updated = old.update(
+                request.getTitle(),
+                request.getEndTime(),
+                null
+        );
+
+        boardRepository.save(updated);
+
+        // 문제 목록 갱신
+        boardProblemRepository.deleteByBoardId(boardId);
+
+        List<BoardProblem> newProblems = new ArrayList<>();
+        int order = 0;
+        for (Long pid : request.getProblemIds()) {
+            newProblems.add(BoardProblem.create(boardId, pid, order++));
+        }
+
+        boardProblemRepository.saveAll(newProblems);
+    }
+
+
+    @Override
+    public void deleteBoard(Long requesterId, Long groupId, Long boardId) {
+        boardRepository.delete(boardId);
+        boardProblemRepository.deleteByBoardId(boardId);
+    }
+}


### PR DESCRIPTION
이슈 번호 : https://github.com/cheonggangsan/BlueStrongMountain_backend/issues/4

## ✅ 이 PR에서 구현한 내용

### 1) **Board 생성 기능 구현**

- `POST /api/v1/groups/{groupId}/boards?requesterId={id}`
- 제목, 내용, 시간 정보, 문제 리스트를 입력받아 Board 생성
- 생성된 Board ID 반환

### 2) **BoardProblem 연결 로직 구현**

- Board에 포함되는 문제 번호 리스트를 저장
- 기존 문제 목록 삭제 후 새로 저장하도록 설계

### 3) **InMemory Repository 기반 저장소 구현 (테스트 목적)**

- `BoardRepositoryImpl`
- `BoardProblemRepositoryImpl`
- Auto-increment ID 발급 및 Map 저장 방식
    - 추후 db에서 자동 increase 하는 방식으로 구현할 예정

### 4) **DTO 구성**

- `BoardCreateRequest`: title, content, startTime, endTime, problemIds 포함
- `BoardDetailResponse` : boardId, title, startTime, endTime, problemIds
- `BoardResponse` : boardId, title, endTime
- `BoardUpdateRequest` : title, endTime, problemIds
- `BoardSearchCondition` :title, status, page, size, sort
    - 위 객체는 페이징과 관련하여 조건을 가지고 들어가지만 모든 조건이 없는 상태로 get 해오는 방식으로 활용 중이다.

### 5) **toString() 오버라이드 추가**

- 도메인 및 DTO 디버깅 용이성 확보

---

## 📂 변경된 주요 컴포넌트/모듈

### 1) **BoardController**

- 요청 파라미터 및 RequestBody 처리
- Service 호출 및 생성된 boardId 반환

### 2) **BoardService / BoardServiceImpl**

- Board 생성 비즈니스 로직 담당
- Board 저장 후 BoardProblem 리스트 저장

### 3) **BoardRepository / BoardRepositoryImpl (InMemory)**

- Map 구조 기반 데이터 저장
- 자동 ID 증가 방식 구현

### 4) **BoardProblemRepository / BoardProblemRepositoryImpl**

- 보드별 문제 리스트 저장/조회/삭제

### 5) **도메인 클래스**

- `Board`
- `BoardProblem`

### 6) **DTO**

- `BoardCreateRequest`

---

## 🧪 동작 흐름/사용 시나리오

### 📌 1) Controller → Service → Repository 요청 흐름

1. **사용자 요청 (POST)**

```
POST /api/v1/groups/{groupId}/boards?requesterId=1
Content-Type: application/json

```

```json
{
  "title": "그래프 심화 세션",
  "content": "최소 컷 / 플로이드 워셜",
  "startTime": "2025-01-01T10:00:00",
  "endTime": "2025-01-01T12:00:00",
  "problemIds": [1000, 1234, 5678]
}

```

1. **Controller**
    - PathVariable(groupId), QueryParam(requesterId) 수집
    - RequestBody 검증 후 Service 호출
2. **Service**
    - Board 엔티티 생성 → BoardRepository.save()
    - problemIds 기반 BoardProblem 리스트 구성
    - BoardProblemRepository.saveAll()
3. **Repository**
    - InMemory Map 기반 저장
    - BoardId는 auto-increment
    - BoardProblem은 boardId를 기준으로 리스트 저장
4. **응답**

```json
{
  "boardId": 42
}

```

---

## 💡 기타

- 현재는 테스트 목적의 InMemory 저장이지만
    
    실제 DB(JPA/MyBatis)로 이관할 때 계층 구조는 동일하게 사용 가능
    
- Board 생성 시 비즈니스 정책(권한 체크 등)이 추가될 여지가 있음
    
    → `requesterId` 기반 owner/manager 검증 기능은 추후 확장 예정
    
    requestId로 넘기는 방식이 아닌 사용자 확인 후 예외처리하는 방식으로 변경할 예정
    
- `toString()` 추가로 로그 추적 및 디버깅 용이
- 생성 API 외 조회/수정/삭제 기능도 구조적으로 확장하기 쉬운 형태