### PR TITLE
[BST-7] Group 기능 구현

### DIFF
--- a/src/main/java/com/ssafy/BlueStrongMountain/config/CorsConfig.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/config/CorsConfig.java
@@ -1,0 +1,16 @@
+package com.ssafy.BlueStrongMountain.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry){
+        registry.addMapping("/**")
+                .allowedOrigins("*")
+                .allowedMethods("*")
+                .allowedHeaders("*");
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/controller/GroupController.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/controller/GroupController.java
@@ -1,0 +1,193 @@
+package com.ssafy.BlueStrongMountain.controller;
+
+import com.ssafy.BlueStrongMountain.dto.GroupCreateRequest;
+import com.ssafy.BlueStrongMountain.dto.GroupSummaryDto;
+import com.ssafy.BlueStrongMountain.dto.GroupUpdateRequest;
+import com.ssafy.BlueStrongMountain.service.GroupMemberService;
+import com.ssafy.BlueStrongMountain.service.GroupService;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/groups")
+public class GroupController {
+
+    private final GroupService groupService;
+    private final GroupMemberService groupMemberService;
+
+    public GroupController(
+            final GroupService groupService,
+            final GroupMemberService groupMemberService
+    ) {
+        this.groupService = groupService;
+        this.groupMemberService = groupMemberService;
+    }
+
+    /**
+     * 그룹 생성
+     */
+    @PostMapping
+    public ResponseEntity<?> createGroup(
+            @RequestParam Long requesterId,
+            @RequestBody GroupCreateRequest request
+    ) {
+        groupService.createGroup(requesterId, request);
+        return ResponseEntity.ok().body(success());
+    }
+
+    /**
+     * 내가 속한 그룹 전체 조회
+     */
+    @GetMapping
+    public ResponseEntity<List<GroupSummaryDto>> findMyGroups(
+            @RequestParam Long requesterId,
+            @RequestParam(required = false) String name
+    ) {
+        //test
+        List<GroupSummaryDto> tmpDtoList = groupService.searchMyGroups(requesterId, name);
+
+
+
+        if (name != null && !name.isBlank()) {
+            return ResponseEntity.ok(groupService.searchMyGroups(requesterId, name));
+        }
+        return ResponseEntity.ok(groupService.findMyGroups(requesterId));
+    }
+
+    /**
+     * 그룹 수정 (OWNER)
+     */
+    @PatchMapping("/{groupId}")
+    public ResponseEntity<?> updateGroup(
+            @RequestParam Long requesterId,
+            @PathVariable Long groupId,
+            @RequestBody GroupUpdateRequest request
+    ) {
+        groupService.updateGroup(requesterId, groupId, request);
+        return ResponseEntity.ok(success());
+    }
+
+    /**
+     * 그룹 소유권 이전
+     */
+    @PatchMapping("/{groupId}/owner")
+    public ResponseEntity<?> changeOwner(
+            @RequestParam Long requesterId,
+            @PathVariable Long groupId,
+            @RequestBody(required = true) OwnerChangeRequest req
+    ) {
+        groupService.changeOwner(requesterId, groupId, req.getNewOwnerId());
+        return ResponseEntity.ok(success());
+    }
+
+    /**
+     * Manager 추가
+     */
+    @PostMapping("/{groupId}/managers")
+    public ResponseEntity<?> addManager(
+            @RequestParam Long requesterId,
+            @PathVariable Long groupId,
+            @RequestBody UserIdRequest request
+    ) {
+        groupMemberService.addManager(requesterId, groupId, request.getUserId());
+        return ResponseEntity.ok(success());
+    }
+
+    /**
+     * Manager 삭제 (bulk)
+     */
+    @DeleteMapping("/{groupId}/managers")
+    public ResponseEntity<?> removeManagers(
+            @RequestParam Long requesterId,
+            @PathVariable Long groupId,
+            @RequestBody ManagerIdsRequest request
+    ) {
+        groupMemberService.removeManagers(requesterId, groupId, request.getManagerIds());
+        return ResponseEntity.ok(success());
+    }
+
+    /**
+     * Member 추가
+     */
+    @PostMapping("/{groupId}/members")
+    public ResponseEntity<?> addMember(
+            @RequestParam Long requesterId,
+            @PathVariable Long groupId,
+            @RequestBody UserIdRequest request
+    ) {
+        groupMemberService.addMember(requesterId, groupId, request.getUserId());
+        return ResponseEntity.ok(success());
+    }
+
+    /**
+     * Member 강제 삭제
+     */
+    @DeleteMapping("/{groupId}/members/{memberId}")
+    public ResponseEntity<?> removeMember(
+            @RequestParam Long requesterId,
+            @PathVariable Long groupId,
+            @PathVariable Long memberId
+    ) {
+        groupMemberService.removeMember(requesterId, groupId, memberId);
+        return ResponseEntity.ok(success());
+    }
+
+    /**
+     * 본인 탈퇴
+     */
+    @DeleteMapping("/{groupId}/members/me")
+    public ResponseEntity<?> leaveGroup(
+            @RequestParam Long requesterId,
+            @PathVariable Long groupId
+    ) {
+        groupMemberService.leaveGroup(requesterId, groupId);
+        return ResponseEntity.ok(success());
+    }
+
+    /**
+     * 공통 응답
+     */
+    private static Res success() {
+        return new Res(true);
+    }
+
+    public static class Res {
+        private final boolean success;
+
+        public Res(final boolean success) {
+            this.success = success;
+        }
+
+        public boolean isSuccess() {
+            return success;
+        }
+    }
+
+    public static class UserIdRequest {
+        private Long userId;
+
+        public Long getUserId() {
+            return userId;
+        }
+    }
+
+    public static class ManagerIdsRequest {
+        private java.util.List<Long> managerIds;
+
+        public java.util.List<Long> getManagerIds() {
+            return managerIds;
+        }
+    }
+
+    public static class OwnerChangeRequest {
+        private Long newOwnerId;
+
+        public Long getNewOwnerId() {
+            return newOwnerId;
+        }
+    }
+}
+

--- a/src/main/java/com/ssafy/BlueStrongMountain/controller/GroupController.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/controller/GroupController.java
@@ -34,7 +34,10 @@ public class GroupController {
             @RequestParam Long requesterId,
             @RequestBody GroupCreateRequest request
     ) {
-        groupService.createGroup(requesterId, request);
+        Long createdGroupId = groupService.createGroup(requesterId, request);
+        System.out.println("!!!!created group id!!!!");
+        System.out.println(createdGroupId);
+
         return ResponseEntity.ok().body(success());
     }
 
@@ -47,13 +50,22 @@ public class GroupController {
             @RequestParam(required = false) String name
     ) {
         //test
-        List<GroupSummaryDto> tmpDtoList = groupService.searchMyGroups(requesterId, name);
+        List<GroupSummaryDto> tmpDtoList;
 
 
 
         if (name != null && !name.isBlank()) {
+
+            tmpDtoList = groupService.searchMyGroups(requesterId, name);
+
             return ResponseEntity.ok(groupService.searchMyGroups(requesterId, name));
         }
+
+        tmpDtoList = groupService.findMyGroups(requesterId);
+        for(GroupSummaryDto gsd : tmpDtoList){
+            System.out.println(gsd.toString());//test
+        }
+
         return ResponseEntity.ok(groupService.findMyGroups(requesterId));
     }
 

--- a/src/main/java/com/ssafy/BlueStrongMountain/controller/GroupController.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/controller/GroupController.java
@@ -90,9 +90,9 @@ public class GroupController {
     public ResponseEntity<?> addManager(
             @RequestParam Long requesterId,
             @PathVariable Long groupId,
-            @RequestBody UserIdRequest request
+            @RequestBody UserIdsRequest request
     ) {
-        groupMemberService.addManager(requesterId, groupId, request.getUserId());
+        groupMemberService.addManagers(requesterId, groupId, request.getUserIds());
         return ResponseEntity.ok(success());
     }
 
@@ -116,22 +116,22 @@ public class GroupController {
     public ResponseEntity<?> addMember(
             @RequestParam Long requesterId,
             @PathVariable Long groupId,
-            @RequestBody UserIdRequest request
+            @RequestBody UserIdsRequest request
     ) {
-        groupMemberService.addMember(requesterId, groupId, request.getUserId());
+        groupMemberService.addMembers(requesterId, groupId, request.getUserIds());
         return ResponseEntity.ok(success());
     }
 
     /**
      * Member 강제 삭제
      */
-    @DeleteMapping("/{groupId}/members/{memberId}")
+    @DeleteMapping("/{groupId}/members")
     public ResponseEntity<?> removeMember(
             @RequestParam Long requesterId,
             @PathVariable Long groupId,
-            @PathVariable Long memberId
+            @RequestBody UserIdsRequest request
     ) {
-        groupMemberService.removeMember(requesterId, groupId, memberId);
+        groupMemberService.removeMembers(requesterId, groupId, request.getUserIds());
         return ResponseEntity.ok(success());
     }
 
@@ -166,11 +166,11 @@ public class GroupController {
         }
     }
 
-    public static class UserIdRequest {
-        private Long userId;
+    public static class UserIdsRequest {
+        private List<Long> userIds;
 
-        public Long getUserId() {
-            return userId;
+        public List<Long> getUserIds() {
+            return userIds;
         }
     }
 

--- a/src/main/java/com/ssafy/BlueStrongMountain/controller/GroupController.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/controller/GroupController.java
@@ -1,11 +1,13 @@
 package com.ssafy.BlueStrongMountain.controller;
 
+import com.ssafy.BlueStrongMountain.dto.BaseResponse;
 import com.ssafy.BlueStrongMountain.dto.GroupCreateRequest;
 import com.ssafy.BlueStrongMountain.dto.GroupSummaryDto;
 import com.ssafy.BlueStrongMountain.dto.GroupUpdateRequest;
 import com.ssafy.BlueStrongMountain.service.GroupMemberService;
 import com.ssafy.BlueStrongMountain.service.GroupService;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -13,24 +15,18 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/groups")
+@RequiredArgsConstructor
 public class GroupController {
 
     private final GroupService groupService;
     private final GroupMemberService groupMemberService;
 
-    public GroupController(
-            final GroupService groupService,
-            final GroupMemberService groupMemberService
-    ) {
-        this.groupService = groupService;
-        this.groupMemberService = groupMemberService;
-    }
 
     /**
      * 그룹 생성
      */
     @PostMapping
-    public ResponseEntity<?> createGroup(
+    public ResponseEntity<BaseResponse> createGroup(
             @RequestParam Long requesterId,
             @RequestBody GroupCreateRequest request
     ) {
@@ -38,7 +34,7 @@ public class GroupController {
         System.out.println("!!!!created group id!!!!");
         System.out.println(createdGroupId);
 
-        return ResponseEntity.ok().body(success());
+        return ResponseEntity.ok(BaseResponse.ok());
     }
 
     /**
@@ -73,133 +69,90 @@ public class GroupController {
      * 그룹 수정 (OWNER)
      */
     @PatchMapping("/{groupId}")
-    public ResponseEntity<?> updateGroup(
+    public ResponseEntity<BaseResponse> updateGroup(
             @RequestParam Long requesterId,
             @PathVariable Long groupId,
             @RequestBody GroupUpdateRequest request
     ) {
         groupService.updateGroup(requesterId, groupId, request);
-        return ResponseEntity.ok(success());
+        return ResponseEntity.ok(BaseResponse.ok());
     }
 
     /**
      * 그룹 소유권 이전
      */
     @PatchMapping("/{groupId}/owner")
-    public ResponseEntity<?> changeOwner(
+    public ResponseEntity<BaseResponse> changeOwner(
             @RequestParam Long requesterId,
             @PathVariable Long groupId,
-            @RequestBody(required = true) OwnerChangeRequest req
+            @RequestBody(required = true) Long newOwnerId
     ) {
-        groupService.changeOwner(requesterId, groupId, req.getNewOwnerId());
-        return ResponseEntity.ok(success());
+        groupService.changeOwner(requesterId, groupId, newOwnerId);
+        return ResponseEntity.ok(BaseResponse.ok());
     }
 
     /**
      * Manager 추가
      */
     @PostMapping("/{groupId}/managers")
-    public ResponseEntity<?> addManager(
+    public ResponseEntity<BaseResponse> addManager(
             @RequestParam Long requesterId,
             @PathVariable Long groupId,
-            @RequestBody UserIdsRequest request
+            @RequestBody List<Long> newManagerIds
     ) {
-        groupMemberService.addManagers(requesterId, groupId, request.getUserIds());
-        return ResponseEntity.ok(success());
+        groupMemberService.addManagers(requesterId, groupId, newManagerIds);
+        return ResponseEntity.ok(BaseResponse.ok());
     }
 
     /**
      * Manager 삭제 (bulk)
      */
     @DeleteMapping("/{groupId}/managers")
-    public ResponseEntity<?> removeManagers(
+    public ResponseEntity<BaseResponse> removeManagers(
             @RequestParam Long requesterId,
             @PathVariable Long groupId,
-            @RequestBody ManagerIdsRequest request
+            @RequestBody List<Long> delManagerIds
     ) {
-        groupMemberService.removeManagers(requesterId, groupId, request.getManagerIds());
-        return ResponseEntity.ok(success());
+        groupMemberService.removeManagers(requesterId, groupId, delManagerIds);
+        return ResponseEntity.ok(BaseResponse.ok());
     }
 
     /**
      * Member 추가
      */
     @PostMapping("/{groupId}/members")
-    public ResponseEntity<?> addMember(
+    public ResponseEntity<BaseResponse> addMember(
             @RequestParam Long requesterId,
             @PathVariable Long groupId,
-            @RequestBody UserIdsRequest request
+            @RequestBody List<Long> newMemberIds
     ) {
-        groupMemberService.addMembers(requesterId, groupId, request.getUserIds());
-        return ResponseEntity.ok(success());
+        groupMemberService.addMembers(requesterId, groupId, newMemberIds);
+        return ResponseEntity.ok(BaseResponse.ok());
     }
 
     /**
      * Member 강제 삭제
      */
     @DeleteMapping("/{groupId}/members")
-    public ResponseEntity<?> removeMember(
+    public ResponseEntity<BaseResponse> removeMember(
             @RequestParam Long requesterId,
             @PathVariable Long groupId,
-            @RequestBody UserIdsRequest request
+            @RequestBody List<Long> delMemberIds
     ) {
-        groupMemberService.removeMembers(requesterId, groupId, request.getUserIds());
-        return ResponseEntity.ok(success());
+        groupMemberService.removeMembers(requesterId, groupId, delMemberIds);
+        return ResponseEntity.ok(BaseResponse.ok());
     }
 
     /**
      * 본인 탈퇴
      */
     @DeleteMapping("/{groupId}/members/me")
-    public ResponseEntity<?> leaveGroup(
+    public ResponseEntity<BaseResponse> leaveGroup(
             @RequestParam Long requesterId,
             @PathVariable Long groupId
     ) {
         groupMemberService.leaveGroup(requesterId, groupId);
-        return ResponseEntity.ok(success());
-    }
-
-    /**
-     * 공통 응답
-     */
-    private static Res success() {
-        return new Res(true);
-    }
-
-    public static class Res {
-        private final boolean success;
-
-        public Res(final boolean success) {
-            this.success = success;
-        }
-
-        public boolean isSuccess() {
-            return success;
-        }
-    }
-
-    public static class UserIdsRequest {
-        private List<Long> userIds;
-
-        public List<Long> getUserIds() {
-            return userIds;
-        }
-    }
-
-    public static class ManagerIdsRequest {
-        private java.util.List<Long> managerIds;
-
-        public java.util.List<Long> getManagerIds() {
-            return managerIds;
-        }
-    }
-
-    public static class OwnerChangeRequest {
-        private Long newOwnerId;
-
-        public Long getNewOwnerId() {
-            return newOwnerId;
-        }
+        return ResponseEntity.ok(BaseResponse.ok());
     }
 }
 

--- a/src/main/java/com/ssafy/BlueStrongMountain/controller/GroupController.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/controller/GroupController.java
@@ -50,21 +50,21 @@ public class GroupController {
             @RequestParam(required = false) String name
     ) {
         //test
-        List<GroupSummaryDto> tmpDtoList;
+        //List<GroupSummaryDto> tmpDtoList;
 
 
 
         if (name != null && !name.isBlank()) {
 
-            tmpDtoList = groupService.searchMyGroups(requesterId, name);
+            //tmpDtoList = groupService.searchMyGroups(requesterId, name);
 
             return ResponseEntity.ok(groupService.searchMyGroups(requesterId, name));
         }
 
-        tmpDtoList = groupService.findMyGroups(requesterId);
-        for(GroupSummaryDto gsd : tmpDtoList){
-            System.out.println(gsd.toString());//test
-        }
+        //tmpDtoList = groupService.findMyGroups(requesterId);
+//        for(GroupSummaryDto gsd : tmpDtoList){
+//            //System.out.println(gsd.toString());//test
+//        }
 
         return ResponseEntity.ok(groupService.findMyGroups(requesterId));
     }

--- a/src/main/java/com/ssafy/BlueStrongMountain/domain/Group.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/domain/Group.java
@@ -65,4 +65,7 @@ public class Group {
         this.ownerId = newOwnerId;
         this.updatedAt = now;
     }
+    private void setId(Long id){
+        this.id = id;
+    }
 }

--- a/src/main/java/com/ssafy/BlueStrongMountain/domain/Group.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/domain/Group.java
@@ -1,0 +1,68 @@
+package com.ssafy.BlueStrongMountain.domain;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class Group {
+
+    private Long id;
+    private String title;
+    private String description;
+    private GroupVisibility visibility;
+    private Long ownerId;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    protected Group() {
+    }
+
+    private Group(
+            final String title,
+            final String description,
+            final GroupVisibility visibility,
+            final Long ownerId,
+            final LocalDateTime createdAt,
+            final LocalDateTime updatedAt
+    ) {
+        this.title = title;
+        this.description = description;
+        this.visibility = visibility;
+        this.ownerId = ownerId;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public static Group create(
+            final String title,
+            final String description,
+            final GroupVisibility visibility,
+            final Long ownerId,
+            final LocalDateTime now
+    ) {
+        return new Group(title, description, visibility, ownerId, now, now);
+    }
+
+    public void update(
+            final String title,
+            final String description,
+            final GroupVisibility visibility,
+            final LocalDateTime now
+    ) {
+        if (title != null) {
+            this.title = title;
+        }
+        if (description != null) {
+            this.description = description;
+        }
+        if (visibility != null) {
+            this.visibility = visibility;
+        }
+        this.updatedAt = now;
+    }
+
+    public void changeOwner(final Long newOwnerId, final LocalDateTime now) {
+        this.ownerId = newOwnerId;
+        this.updatedAt = now;
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/domain/GroupRole.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/domain/GroupRole.java
@@ -1,0 +1,7 @@
+package com.ssafy.BlueStrongMountain.domain;
+
+public enum GroupRole {
+    OWNER,
+    MANAGER,
+    MEMBER
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/domain/GroupVisibility.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/domain/GroupVisibility.java
@@ -1,0 +1,5 @@
+package com.ssafy.BlueStrongMountain.domain;
+
+public enum GroupVisibility {
+    PRIVATE
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/domain/UserGroup.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/domain/UserGroup.java
@@ -1,0 +1,41 @@
+package com.ssafy.BlueStrongMountain.domain;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class UserGroup {
+
+    private Long userId;
+    private Long groupId;
+    private GroupRole role;
+    private LocalDateTime joinedAt;
+
+    protected UserGroup() {
+    }
+
+    private UserGroup(
+            final Long userId,
+            final Long groupId,
+            final GroupRole role,
+            final LocalDateTime joinedAt
+    ) {
+        this.userId = userId;
+        this.groupId = groupId;
+        this.role = role;
+        this.joinedAt = joinedAt;
+    }
+
+    public static UserGroup create(
+            final Long userId,
+            final Long groupId,
+            final GroupRole role,
+            final LocalDateTime joinedAt
+    ) {
+        return new UserGroup(userId, groupId, role, joinedAt);
+    }
+
+    public void changeRole(final GroupRole role) {
+        this.role = role;
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/BaseResponse.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/BaseResponse.java
@@ -1,0 +1,13 @@
+package com.ssafy.BlueStrongMountain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class BaseResponse {
+    private final boolean success;
+    public static BaseResponse ok(){
+        return new BaseResponse(true);
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/GroupCreateRequest.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/GroupCreateRequest.java
@@ -1,9 +1,14 @@
 package com.ssafy.BlueStrongMountain.dto;
 
 import java.util.List;
+
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class GroupCreateRequest {
 
     private String title;

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/GroupCreateRequest.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/GroupCreateRequest.java
@@ -1,0 +1,14 @@
+package com.ssafy.BlueStrongMountain.dto;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class GroupCreateRequest {
+
+    private String title;
+    private List<Long> managerIds;
+    private List<Long> memberIds;
+    private String visibility; // "PRIVATE"
+    private String description;
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/GroupSummaryDto.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/GroupSummaryDto.java
@@ -2,8 +2,10 @@ package com.ssafy.BlueStrongMountain.dto;
 
 import com.ssafy.BlueStrongMountain.domain.Group;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString
 public class GroupSummaryDto {
 
     private Long id;

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/GroupSummaryDto.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/GroupSummaryDto.java
@@ -1,0 +1,49 @@
+package com.ssafy.BlueStrongMountain.dto;
+
+import com.ssafy.BlueStrongMountain.domain.Group;
+import lombok.Getter;
+
+@Getter
+public class GroupSummaryDto {
+
+    private Long id;
+    private String title;
+    private Long ownerId;
+    private String visibility;
+    private int memberCount;
+    private String createdAt;
+    private String updatedAt;
+
+    private GroupSummaryDto(
+            final Long id,
+            final String title,
+            final Long ownerId,
+            final String visibility,
+            final int memberCount,
+            final String createdAt,
+            final String updatedAt
+    ) {
+        this.id = id;
+        this.title = title;
+        this.ownerId = ownerId;
+        this.visibility = visibility;
+        this.memberCount = memberCount;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public static GroupSummaryDto from(
+            final Group group,
+            final int memberCount
+    ) {
+        return new GroupSummaryDto(
+                group.getId(),
+                group.getTitle(),
+                group.getOwnerId(),
+                group.getVisibility().name(),
+                memberCount,
+                group.getCreatedAt().toString(),
+                group.getUpdatedAt().toString()
+        );
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/GroupUpdateRequest.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/GroupUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.ssafy.BlueStrongMountain.dto;
+
+import lombok.Getter;
+
+@Getter
+public class GroupUpdateRequest {
+
+    private String title;
+    private String visibility;
+    private String description;
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/GroupUpdateRequest.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/GroupUpdateRequest.java
@@ -1,8 +1,12 @@
 package com.ssafy.BlueStrongMountain.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class GroupUpdateRequest {
 
     private String title;

--- a/src/main/java/com/ssafy/BlueStrongMountain/exception/CannotRemoveOwnerException.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/exception/CannotRemoveOwnerException.java
@@ -1,0 +1,7 @@
+package com.ssafy.BlueStrongMountain.exception;
+
+public class CannotRemoveOwnerException extends RuntimeException {
+    public CannotRemoveOwnerException(final Long userId, final Long groupId) {
+        super("Cannot remove owner from group. userId=" + userId + ", groupId=" + groupId);
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/exception/CannotTransferOwnershipException.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/exception/CannotTransferOwnershipException.java
@@ -1,0 +1,7 @@
+package com.ssafy.BlueStrongMountain.exception;
+
+public class CannotTransferOwnershipException extends RuntimeException {
+    public CannotTransferOwnershipException(final String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/exception/GroupNotFoundException.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/exception/GroupNotFoundException.java
@@ -1,0 +1,7 @@
+package com.ssafy.BlueStrongMountain.exception;
+
+public class GroupNotFoundException extends RuntimeException {
+    public GroupNotFoundException(final Long groupId) {
+        super("Group not found. groupId=" + groupId);
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/exception/InvalidGroupCreateException.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/exception/InvalidGroupCreateException.java
@@ -1,0 +1,7 @@
+package com.ssafy.BlueStrongMountain.exception;
+
+public class InvalidGroupCreateException extends RuntimeException {
+    public InvalidGroupCreateException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/exception/InvalidGroupUpdateException.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/exception/InvalidGroupUpdateException.java
@@ -1,0 +1,7 @@
+package com.ssafy.BlueStrongMountain.exception;
+
+public class InvalidGroupUpdateException extends RuntimeException {
+    public InvalidGroupUpdateException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/exception/OwnerPermissionRequiredException.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/exception/OwnerPermissionRequiredException.java
@@ -1,0 +1,7 @@
+package com.ssafy.BlueStrongMountain.exception;
+
+public class OwnerPermissionRequiredException extends RuntimeException {
+    public OwnerPermissionRequiredException() {
+        super("Owner permission is required.");
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/exception/UserNotInGroupException.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/exception/UserNotInGroupException.java
@@ -1,0 +1,7 @@
+package com.ssafy.BlueStrongMountain.exception;
+
+public class UserNotInGroupException extends RuntimeException {
+    public UserNotInGroupException(final Long userId, final Long groupId) {
+        super("User is not in group. userId=" + userId + ", groupId=" + groupId);
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/GroupRepository.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/GroupRepository.java
@@ -1,9 +1,17 @@
 package com.ssafy.BlueStrongMountain.repository;
 
+import com.ssafy.BlueStrongMountain.domain.Group;
 import java.util.List;
+import java.util.Optional;
 
 public interface GroupRepository {
     List<Long> findUserIdsByGroupId(Long groupId);
     List<Long> findGroupSolvedProblems(Long groupId);
     List<Long> findUsersSolvedProblems(Long groupId);
+
+    Group save(Group group);
+    Optional<Group> findById(Long groupId);
+    List<Group> findByIds(List<Long> groupIds);
+    List<Group> findByTitleLike(String titleKeyword);
+    void deleteById(Long groupId);
 }

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/InMemoryUserGroupRepository.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/InMemoryUserGroupRepository.java
@@ -20,8 +20,40 @@ public class InMemoryUserGroupRepository implements UserGroupRepository{
 
     @Override
     public UserGroup save(UserGroup userGroup) {
-        groups.computeIfAbsent(userGroup.getGroupId(), k -> new ArrayList<>()).add(userGroup);
-        users.computeIfAbsent(userGroup.getUserId(), k -> new ArrayList<>()).add(userGroup);
+//        groups.computeIfAbsent(userGroup.getGroupId(), k -> new ArrayList<>()).add(userGroup);
+//        users.computeIfAbsent(userGroup.getUserId(), k -> new ArrayList<>()).add(userGroup);
+
+        Long userId = userGroup.getUserId();
+        Long groupId = userGroup.getGroupId();
+
+        List<UserGroup> groupList = groups.getOrDefault(groupId, new ArrayList<>());
+        groupList.removeIf(ug -> ug.getUserId().equals(userId));
+
+        List<UserGroup> userList = users.getOrDefault(userId, new ArrayList<>());
+        userList.removeIf(ug -> ug.getGroupId().equals(groupId));
+
+        groupList.add(userGroup);
+        userList.add(userGroup);
+
+        groups.put(groupId, groupList);
+        users.put(userId, userList);
+
+//        //test
+//
+//        List<UserGroup> members = findByGroupIdAndRole(groupId, GroupRole.MEMBER);
+//        List<UserGroup> managers = findByGroupIdAndRole(groupId, GroupRole.MANAGER);
+//
+//        System.out.println("get members!!!!!!!!!!!1");
+//        for(UserGroup ug : members)
+//            System.out.println(ug.getUserId());
+//
+//        System.out.println("get managers!!!!!!!!!!!!");
+//        for(UserGroup ug : managers){
+//            System.out.println(ug.getUserId());
+//        }
+//
+//        //test
+
         return userGroup;
     }
 
@@ -84,7 +116,7 @@ public class InMemoryUserGroupRepository implements UserGroupRepository{
 
     @Override
     public int countByGroupId(Long groupId) {
-        return 0;
+        return findByGroupIdAndRole(groupId, GroupRole.MEMBER).size();
     }
 
     @Override

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/InMemoryUserGroupRepository.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/InMemoryUserGroupRepository.java
@@ -1,0 +1,107 @@
+package com.ssafy.BlueStrongMountain.repository;
+
+import com.ssafy.BlueStrongMountain.domain.GroupRole;
+import com.ssafy.BlueStrongMountain.domain.UserGroup;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class InMemoryUserGroupRepository implements UserGroupRepository{
+
+    // Key: groupId
+    private final Map<Long, List<UserGroup>> groups = new ConcurrentHashMap<>();
+
+    // Key: userId
+    private final Map<Long, List<UserGroup>> users = new ConcurrentHashMap<>();
+
+    @Override
+    public UserGroup save(UserGroup userGroup) {
+        groups.computeIfAbsent(userGroup.getGroupId(), k -> new ArrayList<>()).add(userGroup);
+        users.computeIfAbsent(userGroup.getUserId(), k -> new ArrayList<>()).add(userGroup);
+        return userGroup;
+    }
+
+    //user
+    @Override
+    public List<UserGroup> findByUserId(Long userId) {
+        return users.getOrDefault(userId, List.of());
+    }
+
+    @Override
+    public List<UserGroup> findByGroupId(Long groupId) {
+        return groups.getOrDefault(groupId, List.of());
+    }
+
+    @Override
+    public Optional<UserGroup> findByUserIdAndGroupId(Long userId, Long groupId) {
+        List<UserGroup> list = groups.get(groupId);
+
+        if (list == null) {
+            return Optional.empty();
+        }
+
+        for (UserGroup ug : list) {
+            if (ug.getUserId().equals(userId)) {
+                return Optional.of(ug);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    public void deleteByUserIdAndGroupId(Long userId, Long groupId) {
+        List<UserGroup> list = groups.get(groupId);
+        if (list != null) {
+            list.removeIf(ug -> ug.getUserId().equals(userId));
+        }
+
+        List<UserGroup> userList = users.get(userId);
+        if (userList != null) {
+            userList.removeIf(ug -> ug.getGroupId().equals(groupId));
+        }
+    }
+
+    @Override
+    public void deleteByGroupIdAndUserIdIn(Long groupId, List<Long> userIds) {
+        List<UserGroup> list = groups.get(groupId);
+
+        if (list != null) {
+            list.removeIf(ug -> userIds.contains(ug.getUserId()));
+        }
+
+        for (Long userId : userIds) {
+            List<UserGroup> userList = users.get(userId);
+            if (userList != null) {
+                userList.removeIf(ug -> ug.getGroupId().equals(groupId));
+            }
+        }
+    }
+
+    @Override
+    public int countByGroupId(Long groupId) {
+        return 0;
+    }
+
+    @Override
+    public List<UserGroup> findByGroupIdAndRole(Long groupId, GroupRole role) {
+        List<UserGroup> result = new ArrayList<>();
+        List<UserGroup> list = groups.get(groupId);
+
+        if (list == null) {
+            return result;
+        }
+
+        for (UserGroup ug : list) {
+            if (ug.getRole() == role) {
+                result.add(ug);
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/MockGroupRepository.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/MockGroupRepository.java
@@ -1,8 +1,14 @@
 package com.ssafy.BlueStrongMountain.repository;
 
+import com.ssafy.BlueStrongMountain.domain.Group;
 import com.ssafy.BlueStrongMountain.dto.GroupProblemDto;
 import com.ssafy.BlueStrongMountain.dto.UserSolvedDto;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Repository;
 
@@ -20,6 +26,7 @@ public class MockGroupRepository implements GroupRepository{
             new UserSolvedDto(1L, 1409L, 1L),
             new UserSolvedDto(2L, 2004L, 1L)
     );
+
 
     @Override
     public List<Long> findUserIdsByGroupId(Long groupId) {
@@ -39,4 +46,63 @@ public class MockGroupRepository implements GroupRepository{
                 .map(UserSolvedDto::getProblemId)
                 .collect(Collectors.toList());
     }
+    private final Map<Long, Group> store = new ConcurrentHashMap<>();
+    private final AtomicLong sequence = new AtomicLong(1);
+
+
+    @Override
+    public Group save(Group group) {
+        if (group.getId() == null) {
+            Long id = sequence.getAndIncrement();
+            setId(group, id);
+        }
+
+        store.put(group.getId(), group);
+        return group;
+    }
+
+    @Override
+    public Optional<Group> findById(final Long groupId) {
+        return Optional.ofNullable(store.get(groupId));
+    }
+
+    // 안필요할 수도?
+    @Override
+    public List<Group> findByIds(final List<Long> groupIds) {
+        List<Group> result = new ArrayList<>();
+
+        for (Long id : groupIds) {
+            if (store.containsKey(id)) {
+                result.add(store.get(id));
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public List<Group> findByTitleLike(String titleKeyword) {
+        List<Group> result = new ArrayList<>();
+
+        for (Group group : store.values()) {
+            if (group.getTitle().toLowerCase().contains(titleKeyword.toLowerCase())) {
+                result.add(group);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public void deleteById(Long groupId) {
+        store.remove(groupId);
+    }
+    private void setId(final Group group, final Long id) {
+        try {
+            var field = Group.class.getDeclaredField("id");
+            field.setAccessible(true);
+            field.set(group, id);
+        } catch (Exception e) {
+            throw new RuntimeException("Reflection error: cannot set ID", e);
+        }
+    }
+
 }

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/UserGroupRepository.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/UserGroupRepository.java
@@ -1,0 +1,18 @@
+package com.ssafy.BlueStrongMountain.repository;
+
+import com.ssafy.BlueStrongMountain.domain.GroupRole;
+import com.ssafy.BlueStrongMountain.domain.UserGroup;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface UserGroupRepository {
+    UserGroup save(UserGroup userGroup);
+    List<UserGroup> findByUserId(Long userId);
+    List<UserGroup> findByGroupId(Long groupId);
+    Optional<UserGroup> findByUserIdAndGroupId(Long userId, Long groupId);
+    void deleteByUserIdAndGroupId(Long userId, Long groupId);
+    void deleteByGroupIdAndUserIdIn(Long groupId, List<Long> userIds);
+    int countByGroupId(Long groupId);
+    List<UserGroup> findByGroupIdAndRole(Long groupId, GroupRole role);
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/GroupMemberService.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/GroupMemberService.java
@@ -1,9 +1,11 @@
 package com.ssafy.BlueStrongMountain.service;
 
+import java.util.List;
+
 public interface GroupMemberService {
-    void addManager(Long requesterId, Long groupId, Long userId);
-    void removeManagers(Long requesterId, Long groupId, java.util.List<Long> managerIds);
-    void addMember(Long requesterId, Long groupId, Long userId);
-    void removeMember(Long requesterId, Long groupId, Long memberId);
+    void addManagers(Long requesterId, Long groupId, List<Long> userIds);
+    void removeManagers(Long requesterId, Long groupId, List<Long> managerIds);
+    void addMembers(Long requesterId, Long groupId, List<Long> userIds);
+    void removeMembers(Long requesterId, Long groupId, List<Long> userIds);
     void leaveGroup(Long requesterId, Long groupId);
 }

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/GroupMemberService.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/GroupMemberService.java
@@ -1,0 +1,9 @@
+package com.ssafy.BlueStrongMountain.service;
+
+public interface GroupMemberService {
+    void addManager(Long requesterId, Long groupId, Long userId);
+    void removeManagers(Long requesterId, Long groupId, java.util.List<Long> managerIds);
+    void addMember(Long requesterId, Long groupId, Long userId);
+    void removeMember(Long requesterId, Long groupId, Long memberId);
+    void leaveGroup(Long requesterId, Long groupId);
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/GroupMemberServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/GroupMemberServiceImpl.java
@@ -1,0 +1,129 @@
+package com.ssafy.BlueStrongMountain.service;
+
+import com.ssafy.BlueStrongMountain.domain.GroupRole;
+import com.ssafy.BlueStrongMountain.domain.UserGroup;
+import com.ssafy.BlueStrongMountain.exception.CannotRemoveOwnerException;
+import com.ssafy.BlueStrongMountain.exception.UserNotInGroupException;
+import com.ssafy.BlueStrongMountain.repository.UserGroupRepository;
+import com.ssafy.BlueStrongMountain.service.validator.GroupAuthorityService;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class GroupMemberServiceImpl implements GroupMemberService {
+
+    private final UserGroupRepository userGroupRepository;
+    private final GroupAuthorityService groupAuthorityService;
+
+    public GroupMemberServiceImpl(
+            final UserGroupRepository userGroupRepository,
+            final GroupAuthorityService groupAuthorityService
+    ) {
+        this.userGroupRepository = userGroupRepository;
+        this.groupAuthorityService = groupAuthorityService;
+    }
+
+    @Override
+    public void addManager(
+            final Long requesterId,
+            final Long groupId,
+            final Long userId
+    ) {
+        groupAuthorityService.validateOwner(requesterId, groupId);
+
+        final UserGroup target = userGroupRepository.findByUserIdAndGroupId(userId, groupId)
+                .orElseThrow(() -> new UserNotInGroupException(userId, groupId));
+
+        if (target.getRole() == GroupRole.MANAGER) {
+            //throw new AlreadyManagerException(userId, groupId);
+        }
+
+        if (target.getRole() == GroupRole.OWNER) {
+            throw new CannotRemoveOwnerException(userId, groupId);
+        }
+
+        target.changeRole(GroupRole.MANAGER);
+        userGroupRepository.save(target);
+    }
+
+    @Override
+    public void removeManagers(
+            final Long requesterId,
+            final Long groupId,
+            final List<Long> managerIds
+    ) {
+        groupAuthorityService.validateOwner(requesterId, groupId);
+
+        for (Long managerId : managerIds) {
+            if (managerId.equals(requesterId)) {
+                throw new CannotRemoveOwnerException(managerId, groupId);
+            }
+
+            final UserGroup userGroup = userGroupRepository.findByUserIdAndGroupId(managerId, groupId)
+                    .orElseThrow(() -> new UserNotInGroupException(managerId, groupId));
+
+            if (userGroup.getRole() == GroupRole.OWNER) {
+                throw new CannotRemoveOwnerException(managerId, groupId);
+            }
+
+            userGroup.changeRole(GroupRole.MEMBER);
+            userGroupRepository.save(userGroup);
+        }
+    }
+
+    @Override
+    public void addMember(
+            final Long requesterId,
+            final Long groupId,
+            final Long userId
+    ) {
+        groupAuthorityService.validateManager(requesterId, groupId);
+
+        final boolean exists = userGroupRepository.findByUserIdAndGroupId(userId, groupId).isPresent();
+        if (exists) {
+            //중복 사용자 발생 예외 추가
+        }
+
+        final LocalDateTime now = LocalDateTime.now();
+        final UserGroup userGroup = UserGroup.create(userId, groupId, GroupRole.MEMBER, now);
+        userGroupRepository.save(userGroup);
+    }
+
+    @Override
+    public void removeMember(
+            final Long requesterId,
+            final Long groupId,
+            final Long memberId
+    ) {
+        groupAuthorityService.validateOwner(requesterId, groupId);
+
+        if (memberId.equals(requesterId)) {
+            throw new CannotRemoveOwnerException(memberId, groupId);
+        }
+
+        final UserGroup userGroup = userGroupRepository.findByUserIdAndGroupId(memberId, groupId)
+                .orElseThrow(() -> new UserNotInGroupException(memberId, groupId));
+
+        if (userGroup.getRole() == GroupRole.OWNER) {
+            throw new CannotRemoveOwnerException(memberId, groupId);
+        }
+
+        userGroupRepository.deleteByUserIdAndGroupId(memberId, groupId);
+    }
+
+    @Override
+    public void leaveGroup(
+            final Long requesterId,
+            final Long groupId
+    ) {
+        final UserGroup userGroup = userGroupRepository.findByUserIdAndGroupId(requesterId, groupId)
+                .orElseThrow(() -> new UserNotInGroupException(requesterId, groupId));
+
+        if (userGroup.getRole() == GroupRole.OWNER) {
+            throw new CannotRemoveOwnerException(requesterId, groupId);
+        }
+
+        userGroupRepository.deleteByUserIdAndGroupId(requesterId, groupId);
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/GroupService.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/GroupService.java
@@ -1,0 +1,14 @@
+package com.ssafy.BlueStrongMountain.service;
+
+import com.ssafy.BlueStrongMountain.dto.GroupCreateRequest;
+import com.ssafy.BlueStrongMountain.dto.GroupSummaryDto;
+import com.ssafy.BlueStrongMountain.dto.GroupUpdateRequest;
+import java.util.List;
+
+public interface GroupService {
+    Long createGroup(Long ownerId, GroupCreateRequest request);
+    List<GroupSummaryDto> findMyGroups(Long requesterId);
+    List<GroupSummaryDto> searchMyGroups(Long requesterId, String name);
+    void updateGroup(Long requesterId, Long groupId, GroupUpdateRequest request);
+    void changeOwner(Long requesterId, Long groupId, Long newOwnerId);
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/GroupServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/GroupServiceImpl.java
@@ -1,0 +1,178 @@
+package com.ssafy.BlueStrongMountain.service;
+
+import com.ssafy.BlueStrongMountain.domain.Group;
+import com.ssafy.BlueStrongMountain.domain.GroupRole;
+import com.ssafy.BlueStrongMountain.domain.GroupVisibility;
+import com.ssafy.BlueStrongMountain.domain.UserGroup;
+import com.ssafy.BlueStrongMountain.dto.GroupCreateRequest;
+import com.ssafy.BlueStrongMountain.dto.GroupSummaryDto;
+import com.ssafy.BlueStrongMountain.dto.GroupUpdateRequest;
+import com.ssafy.BlueStrongMountain.exception.GroupNotFoundException;
+import com.ssafy.BlueStrongMountain.repository.GroupRepository;
+import com.ssafy.BlueStrongMountain.repository.UserGroupRepository;
+
+import com.ssafy.BlueStrongMountain.service.validator.GroupAuthorityService;
+import com.ssafy.BlueStrongMountain.service.validator.GroupValidator;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class GroupServiceImpl implements GroupService {
+
+    private final GroupRepository groupRepository;
+    private final UserGroupRepository userGroupRepository;
+    private final GroupValidator groupValidator;
+    private final GroupAuthorityService groupAuthorityService;
+
+
+    public GroupServiceImpl(
+            final GroupRepository groupRepository,
+            final UserGroupRepository userGroupRepository,
+            final GroupValidator groupValidator,
+            final GroupAuthorityService groupAuthorityService
+    ) {
+        this.groupRepository = groupRepository;
+        this.userGroupRepository = userGroupRepository;
+        this.groupValidator = groupValidator;
+        this.groupAuthorityService = groupAuthorityService;
+    }
+
+    @Override
+    public Long createGroup(
+            final Long ownerId,
+            final GroupCreateRequest request
+    ) {
+        groupValidator.validateCreateRequest(request);
+
+        final LocalDateTime now = LocalDateTime.now();
+        final GroupVisibility visibility = GroupVisibility.PRIVATE;
+
+        final Group group = Group.create(
+                request.getTitle(),
+                request.getDescription(),
+                visibility,
+                ownerId,
+                now
+        );
+
+        final Group saved = groupRepository.save(group);
+
+        final UserGroup ownerUserGroup = UserGroup.create(ownerId, saved.getId(), GroupRole.OWNER, now);
+        userGroupRepository.save(ownerUserGroup);
+
+        if (request.getManagerIds() != null) {
+            for (Long managerId : request.getManagerIds()) {
+                final UserGroup userGroup = UserGroup.create(managerId, saved.getId(), GroupRole.MANAGER, now);
+                userGroupRepository.save(userGroup);
+            }
+        }
+
+        if (request.getMemberIds() != null) {
+            for (Long memberId : request.getMemberIds()) {
+                final UserGroup userGroup = UserGroup.create(memberId, saved.getId(), GroupRole.MEMBER, now);
+                userGroupRepository.save(userGroup);
+            }
+        }
+
+        return saved.getId();
+    }
+
+    @Override
+    public List<GroupSummaryDto> findMyGroups(final Long requesterId) {
+        final List<Long> myGroupIds = userGroupRepository.findByUserId(requesterId).stream()
+                .map(UserGroup::getGroupId)
+                .toList();
+
+        if (myGroupIds.isEmpty()) {
+            return List.of();
+        }
+
+        final List<Group> groups = groupRepository.findByIds(myGroupIds);
+
+        final List<GroupSummaryDto> result = new ArrayList<>();
+        for (Group group : groups) {
+            final int memberCount = userGroupRepository.countByGroupId(group.getId());
+            result.add(GroupSummaryDto.from(group, memberCount));
+        }
+
+        result.sort(Comparator.comparing(GroupSummaryDto::getUpdatedAt).reversed());
+
+        return result;
+    }
+
+    @Override
+    public List<GroupSummaryDto> searchMyGroups(
+            final Long requesterId,
+            final String name
+    ) {
+        final List<GroupSummaryDto> myGroups = findMyGroups(requesterId);
+
+        if (name == null || name.isBlank()) {
+            return myGroups;
+        }
+
+        final String keyword = name.toLowerCase();
+        final List<GroupSummaryDto> filtered = new ArrayList<>();
+
+        for (GroupSummaryDto dto : myGroups) {
+            if (dto.getTitle().toLowerCase().contains(keyword)) {
+                filtered.add(dto);
+            }
+        }
+
+        return filtered;
+    }
+
+    @Override
+    public void updateGroup(
+            final Long requesterId,
+            final Long groupId,
+            final GroupUpdateRequest request
+    ) {
+        groupValidator.validateUpdateRequest(request);
+        groupAuthorityService.validateOwner(requesterId, groupId);
+
+        final Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new GroupNotFoundException(groupId));
+
+        final LocalDateTime now = LocalDateTime.now();
+        group.update(
+                request.getTitle(),
+                request.getDescription(),
+                GroupVisibility.PRIVATE,
+                now
+        );
+
+        groupRepository.save(group);
+    }
+
+    @Override
+    public void changeOwner(
+            final Long requesterId,
+            final Long groupId,
+            final Long newOwnerId
+    ) {
+        groupAuthorityService.validateOwnerTransferable(requesterId, groupId, newOwnerId);
+
+        final Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new GroupNotFoundException(groupId));
+
+        final LocalDateTime now = LocalDateTime.now();
+        group.changeOwner(newOwnerId, now);
+        groupRepository.save(group);
+
+        final UserGroup oldOwner = userGroupRepository.findByUserIdAndGroupId(requesterId, groupId)
+                .orElseThrow(() -> new GroupNotFoundException(groupId));
+        oldOwner.changeRole(GroupRole.MEMBER);
+        userGroupRepository.save(oldOwner);
+
+        final UserGroup newOwner = userGroupRepository.findByUserIdAndGroupId(newOwnerId, groupId)
+                .orElseThrow(() -> new GroupNotFoundException(groupId));
+        newOwner.changeRole(GroupRole.OWNER);
+        userGroupRepository.save(newOwner);
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/GroupServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/GroupServiceImpl.java
@@ -99,6 +99,14 @@ public class GroupServiceImpl implements GroupService {
             result.add(GroupSummaryDto.from(group, memberCount));
         }
 
+//        //test
+//        System.out.println("group size in findMyGroups = " + groups.size());
+//        for(Group group : groups){
+//            final int memberCount = userGroupRepository.countByGroupId(group.getId());
+//            System.out.println("group id : " +group.getId() + " memberCount = " + memberCount);
+//        }
+//        //test
+
         result.sort(Comparator.comparing(GroupSummaryDto::getUpdatedAt).reversed());
 
         return result;
@@ -163,7 +171,12 @@ public class GroupServiceImpl implements GroupService {
 
         final LocalDateTime now = LocalDateTime.now();
         group.changeOwner(newOwnerId, now);
-        groupRepository.save(group);
+
+//        //test
+//        System.out.println("before group size" + userGroupRepository.findByUserId(requesterId).size());
+//        groupRepository.save(group);
+//        System.out.println("after group size" + userGroupRepository.findByUserId(requesterId).size());
+//        //test
 
         final UserGroup oldOwner = userGroupRepository.findByUserIdAndGroupId(requesterId, groupId)
                 .orElseThrow(() -> new GroupNotFoundException(groupId));

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/validator/GroupAuthorityService.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/validator/GroupAuthorityService.java
@@ -1,0 +1,10 @@
+package com.ssafy.BlueStrongMountain.service.validator;
+
+public interface GroupAuthorityService {
+    void validateOwner(Long userId, Long groupId);
+    void validateManager(Long userId, Long groupId);
+    void validateGroupMember(Long userId, Long groupId);
+    void validateNotOwner(Long userId, Long groupId);
+    void validateUserInGroup(Long userId, Long groupId);
+    void validateOwnerTransferable(Long requesterId, Long groupId, Long newOwnerId);
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/validator/GroupAuthorityServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/validator/GroupAuthorityServiceImpl.java
@@ -1,0 +1,76 @@
+package com.ssafy.BlueStrongMountain.service.validator;
+
+import com.ssafy.BlueStrongMountain.domain.GroupRole;
+import com.ssafy.BlueStrongMountain.domain.UserGroup;
+import com.ssafy.BlueStrongMountain.exception.CannotTransferOwnershipException;
+import com.ssafy.BlueStrongMountain.exception.OwnerPermissionRequiredException;
+import com.ssafy.BlueStrongMountain.exception.UserNotInGroupException;
+import com.ssafy.BlueStrongMountain.repository.UserGroupRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GroupAuthorityServiceImpl implements GroupAuthorityService {
+
+    private final UserGroupRepository userGroupRepository;
+
+    public GroupAuthorityServiceImpl(final UserGroupRepository userGroupRepository) {
+        this.userGroupRepository = userGroupRepository;
+    }
+
+    @Override
+    public void validateOwner(final Long userId, final Long groupId) {
+        final UserGroup userGroup = getUserGroupOrThrow(userId, groupId);
+
+        if (userGroup.getRole() != GroupRole.OWNER) {
+            throw new OwnerPermissionRequiredException();
+        }
+    }
+
+    @Override
+    public void validateManager(final Long userId, final Long groupId) {
+        final UserGroup userGroup = getUserGroupOrThrow(userId, groupId);
+
+        if (userGroup.getRole() == GroupRole.MEMBER) {
+            throw new OwnerPermissionRequiredException();
+        }
+    }
+
+    @Override
+    public void validateGroupMember(final Long userId, final Long groupId) {
+        getUserGroupOrThrow(userId, groupId);
+    }
+
+    @Override
+    public void validateNotOwner(final Long userId, final Long groupId) {
+//        final UserGroup userGroup = getUserGroupOrThrow(userId, groupId);
+//
+//        if (userGroup.getRole() == GroupRole.OWNER) {
+//            throw new CannotTransferOwnershipException("Owner cannot perform this action.");
+//        }
+    }
+
+    @Override
+    public void validateUserInGroup(final Long userId, final Long groupId) {
+        getUserGroupOrThrow(userId, groupId);
+    }
+
+    @Override
+    public void validateOwnerTransferable(
+            final Long requesterId,
+            final Long groupId,
+            final Long newOwnerId
+    ) {
+        validateOwner(requesterId, groupId);
+
+        if (requesterId.equals(newOwnerId)) {
+            throw new CannotTransferOwnershipException("Owner cannot transfer ownership to self.");
+        }
+
+        getUserGroupOrThrow(newOwnerId, groupId);
+    }
+
+    private UserGroup getUserGroupOrThrow(final Long userId, final Long groupId) {
+        return userGroupRepository.findByUserIdAndGroupId(userId, groupId)
+                .orElseThrow(() -> new UserNotInGroupException(userId, groupId));
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/validator/GroupValidator.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/validator/GroupValidator.java
@@ -1,0 +1,77 @@
+package com.ssafy.BlueStrongMountain.service.validator;
+
+import com.ssafy.BlueStrongMountain.dto.GroupCreateRequest;
+import com.ssafy.BlueStrongMountain.dto.GroupUpdateRequest;
+import com.ssafy.BlueStrongMountain.exception.InvalidGroupCreateException;
+import com.ssafy.BlueStrongMountain.exception.InvalidGroupUpdateException;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GroupValidator {
+
+    public void validateCreateRequest(final GroupCreateRequest request) {
+        if (request == null) {
+            throw new InvalidGroupCreateException("Request must not be null.");
+        }
+
+        if (request.getTitle() == null || request.getTitle().isBlank()) {
+            throw new InvalidGroupCreateException("Group title must not be empty.");
+        }
+
+        validateDuplicateIds(request.getManagerIds(), request.getMemberIds());
+    }
+
+    public void validateUpdateRequest(final GroupUpdateRequest request) {
+        if (request == null) {
+            throw new InvalidGroupUpdateException("Request must not be null.");
+        }
+    }
+
+//    public void validateDuplicateMemberIds(final List<Long> memberIds) {
+//        validateDuplicate(memberIds, "memberIds");
+//    }
+//
+//    public void validateDuplicateManagerIds(final List<Long> managerIds) {
+//        validateDuplicate(managerIds, "managerIds");
+//    }
+
+    private void validateDuplicateIds(
+            final List<Long> managerIds,
+            final List<Long> memberIds
+    ) {
+        final Set<Long> set = new HashSet<>();
+        if (managerIds != null) {
+            for (Long id : managerIds) {
+                if (set.contains(id)) {
+                    throw new InvalidGroupCreateException("Duplicate id in managerIds and memberIds. id=" + id);
+                }
+                set.add(id);
+            }
+        }
+        if (memberIds != null) {
+            for (Long id : memberIds) {
+                if (set.contains(id)) {
+                    throw new InvalidGroupCreateException("Duplicate id in managerIds and memberIds. id=" + id);
+                }
+                set.add(id);
+            }
+        }
+    }
+
+//    private void validateDuplicate(final List<Long> ids, final String fieldName) {
+//        if (ids == null) {
+//            return;
+//        }
+//        final Set<Long> set = new HashSet<>();
+//        for (Long id : ids) {
+//            if (set.contains(id)) {
+//                throw new InvalidGroupCreateException("Duplicate id in " + fieldName + ". id=" + id);
+//            }
+//            set.add(id);
+//        }
+//    }
+}

--- a/src/test/java/com/ssafy/BlueStrongMountain/BlueStrongMountainApplicationTests.java
+++ b/src/test/java/com/ssafy/BlueStrongMountain/BlueStrongMountainApplicationTests.java
@@ -1,0 +1,15 @@
+package com.ssafy.BlueStrongMountain;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class BlueStrongMountainApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}
+
+

--- a/src/test/java/com/ssafy/BlueStrongMountain/controller/GroupControllerTest.java
+++ b/src/test/java/com/ssafy/BlueStrongMountain/controller/GroupControllerTest.java
@@ -1,0 +1,360 @@
+package com.ssafy.BlueStrongMountain.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ssafy.BlueStrongMountain.dto.GroupCreateRequest;
+import com.ssafy.BlueStrongMountain.dto.GroupSummaryDto;
+import com.ssafy.BlueStrongMountain.dto.GroupUpdateRequest;
+import com.ssafy.BlueStrongMountain.service.GroupMemberService;
+import com.ssafy.BlueStrongMountain.service.GroupService;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(GroupController.class)
+class GroupControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private GroupService groupService;
+
+    @MockitoBean
+    private GroupMemberService groupMemberService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    /**
+     * [테스트 목적]
+     * - POST /api/v1/groups
+     * - requesterId를 query parameter로 넘기고, GroupCreateRequest를 body로 넘겼을 때
+     * - GroupService.createGroup 이 올바르게 호출되는지
+     * - 응답으로 {"success": true} JSON 이 내려오는지 검증
+     */
+    @Test
+    @DisplayName("그룹 생성 API - 성공")
+    void createGroup_success() throws Exception {
+        // given
+        Long requesterId = 1L;
+
+        // GroupCreateRequest(title, managerIds, memberIds, visibility, description)
+        GroupCreateRequest request = new GroupCreateRequest(
+                "알고리즘 스터디",
+                List.of(2L, 3L),              // managerIds
+                List.of(4L, 5L),              // memberIds
+                "PUBLIC",                     // visibility
+                "매주 화요일 문제 풀이"        // description
+        );
+
+        given(groupService.createGroup(eq(requesterId), any(GroupCreateRequest.class)))
+                .willReturn(10L);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/groups")
+                        .param("requesterId", String.valueOf(requesterId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        then(groupService).should()
+                .createGroup(eq(requesterId), any(GroupCreateRequest.class));
+    }
+
+    /**
+     * [테스트 목적]
+     * - GET /api/v1/groups?requesterId=1 (name 없음)
+     * - name 파라미터가 없을 때 groupService.findMyGroups()가 호출되는지
+     * - 응답이 List<GroupSummaryDto> JSON 배열로 내려오는지 검증
+     */
+    @Test
+    @DisplayName("내가 속한 그룹 조회 - name 없이 전체 조회")
+    void findMyGroups_withoutName() throws Exception {
+        // given
+        Long requesterId = 1L;
+
+        // GroupSummaryDto는 private 생성자라 new 불가 → mock으로 대체
+        GroupSummaryDto dto1 = Mockito.mock(GroupSummaryDto.class);
+        GroupSummaryDto dto2 = Mockito.mock(GroupSummaryDto.class);
+
+        given(groupService.findMyGroups(requesterId))
+                .willReturn(List.of(dto1, dto2));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/groups")
+                        .param("requesterId", String.valueOf(requesterId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2)); // 배열 길이만 검증
+
+        then(groupService).should()
+                .findMyGroups(requesterId);
+        then(groupService).shouldHaveNoMoreInteractions();
+    }
+
+    /**
+     * [테스트 목적]
+     * - GET /api/v1/groups?requesterId=1&name=algo
+     * - name 파라미터가 존재할 때 groupService.searchMyGroups()가 호출되는지
+     * - 응답이 검색 결과 List<GroupSummaryDto> JSON 배열인지 검증
+     */
+    @Test
+    @DisplayName("내가 속한 그룹 조회 - name으로 검색")
+    void findMyGroups_withName() throws Exception {
+        // given
+        Long requesterId = 1L;
+        String name = "알고";
+
+        GroupSummaryDto dto = Mockito.mock(GroupSummaryDto.class);
+
+        given(groupService.searchMyGroups(requesterId, name))
+                .willReturn(List.of(dto));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/groups")
+                        .param("requesterId", String.valueOf(requesterId))
+                        .param("name", name))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1));
+
+        then(groupService).should()
+                .searchMyGroups(requesterId, name);
+        then(groupService).shouldHaveNoMoreInteractions();
+    }
+
+    /**
+     * [테스트 목적]
+     * - PATCH /api/v1/groups/{groupId}
+     * - 그룹 수정 요청이 들어왔을 때 groupService.updateGroup이 올바르게 호출되는지
+     * - 응답으로 {"success": true}가 내려오는지 검증
+     *
+     * GroupUpdateRequest(title, visibility, description) 순서 주의
+     */
+    @Test
+    @DisplayName("그룹 수정 API - 성공")
+    void updateGroup_success() throws Exception {
+        // given
+        Long requesterId = 1L;
+        Long groupId = 100L;
+
+        GroupUpdateRequest request = new GroupUpdateRequest(
+                "수정된 스터디 이름",
+                "PRIVATE",
+                "수정된 설명"
+        );
+
+        // when & then
+        mockMvc.perform(patch("/api/v1/groups/{groupId}", groupId)
+                        .param("requesterId", String.valueOf(requesterId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        then(groupService).should()
+                .updateGroup(eq(requesterId), eq(groupId), any(GroupUpdateRequest.class));
+    }
+
+    /**
+     * [테스트 목적]
+     * - PATCH /api/v1/groups/{groupId}/owner
+     * - 소유권 변경 요청이 들어왔을 때 groupService.changeOwner가 올바르게 호출되는지
+     * - newOwnerId가 JSON body에서 제대로 바인딩되는지
+     * - 응답으로 {"success": true}가 내려오는지 검증
+     */
+    @Test
+    @DisplayName("그룹 소유권 변경 API - 성공")
+    void changeOwner_success() throws Exception {
+        // given
+        Long requesterId = 1L;
+        Long groupId = 100L;
+        Long newOwnerId = 2L;
+
+        String body = """
+                {"newOwnerId": %d}
+                """.formatted(newOwnerId);
+
+        // when & then
+        mockMvc.perform(patch("/api/v1/groups/{groupId}/owner", groupId)
+                        .param("requesterId", String.valueOf(requesterId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        then(groupService).should()
+                .changeOwner(requesterId, groupId, newOwnerId);
+    }
+
+    /**
+     * [테스트 목적]
+     * - POST /api/v1/groups/{groupId}/managers
+     * - Manager 추가 요청이 들어왔을 때 groupMemberService.addManagers가
+     *   requesterId, groupId, userIds로 올바르게 호출되는지 검증
+     */
+    @Test
+    @DisplayName("Manager 추가 API - 성공")
+    void addManagers_success() throws Exception {
+        // given
+        Long requesterId = 1L;
+        Long groupId = 100L;
+        List<Long> userIds = List.of(2L, 3L);
+
+        String body = objectMapper.writeValueAsString(
+                new UserIdsRequestStub(userIds)
+        );
+
+        // when & then
+        mockMvc.perform(post("/api/v1/groups/{groupId}/managers", groupId)
+                        .param("requesterId", String.valueOf(requesterId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        then(groupMemberService).should()
+                .addManagers(eq(requesterId), eq(groupId), eq(userIds));
+    }
+
+    /**
+     * [테스트 목적]
+     * - DELETE /api/v1/groups/{groupId}/managers
+     * - Manager 삭제(bulk) 요청이 들어왔을 때 groupMemberService.removeManagers가
+     *   requesterId, groupId, managerIds로 올바르게 호출되는지 검증
+     */
+    @Test
+    @DisplayName("Manager 삭제 API - 성공")
+    void removeManagers_success() throws Exception {
+        // given
+        Long requesterId = 1L;
+        Long groupId = 100L;
+        List<Long> managerIds = List.of(2L, 3L);
+
+        String body = """
+                {"managerIds": [2, 3]}
+                """;
+
+        // when & then
+        mockMvc.perform(delete("/api/v1/groups/{groupId}/managers", groupId)
+                        .param("requesterId", String.valueOf(requesterId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        then(groupMemberService).should()
+                .removeManagers(eq(requesterId), eq(groupId), eq(managerIds));
+    }
+
+    /**
+     * [테스트 목적]
+     * - POST /api/v1/groups/{groupId}/members
+     * - Member 추가 요청이 들어왔을 때 groupMemberService.addMembers가
+     *   requesterId, groupId, userIds로 올바르게 호출되는지 검증
+     */
+    @Test
+    @DisplayName("Member 추가 API - 성공")
+    void addMembers_success() throws Exception {
+        // given
+        Long requesterId = 1L;
+        Long groupId = 100L;
+        List<Long> userIds = List.of(4L, 5L);
+
+        String body = objectMapper.writeValueAsString(
+                new UserIdsRequestStub(userIds)
+        );
+
+        // when & then
+        mockMvc.perform(post("/api/v1/groups/{groupId}/members", groupId)
+                        .param("requesterId", String.valueOf(requesterId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        then(groupMemberService).should()
+                .addMembers(eq(requesterId), eq(groupId), eq(userIds));
+    }
+
+    /**
+     * [테스트 목적]
+     * - DELETE /api/v1/groups/{groupId}/members
+     * - Member 강제 삭제 요청이 들어왔을 때 groupMemberService.removeMembers가
+     *   requesterId, groupId, userIds로 올바르게 호출되는지 검증
+     */
+    @Test
+    @DisplayName("Member 강제 삭제 API - 성공")
+    void removeMembers_success() throws Exception {
+        // given
+        Long requesterId = 1L;
+        Long groupId = 100L;
+        List<Long> userIds = List.of(4L, 5L);
+
+        String body = objectMapper.writeValueAsString(
+                new UserIdsRequestStub(userIds)
+        );
+
+        // when & then
+        mockMvc.perform(delete("/api/v1/groups/{groupId}/members", groupId)
+                        .param("requesterId", String.valueOf(requesterId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        then(groupMemberService).should()
+                .removeMembers(eq(requesterId), eq(groupId), eq(userIds));
+    }
+
+    /**
+     * [테스트 목적]
+     * - DELETE /api/v1/groups/{groupId}/members/me
+     * - 본인 탈퇴 요청이 들어왔을 때 groupMemberService.leaveGroup이
+     *   requesterId, groupId로 올바르게 호출되는지 검증
+     */
+    @Test
+    @DisplayName("그룹 탈퇴 API - 성공")
+    void leaveGroup_success() throws Exception {
+        // given
+        Long requesterId = 1L;
+        Long groupId = 100L;
+
+        // when & then
+        mockMvc.perform(delete("/api/v1/groups/{groupId}/members/me", groupId)
+                        .param("requesterId", String.valueOf(requesterId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        then(groupMemberService).should()
+                .leaveGroup(requesterId, groupId);
+    }
+
+    /**
+     * 컨트롤러 내부 static class(UserIdsRequest)가 setter가 없어
+     * 테스트 코드에서 JSON 직렬화 용으로 사용하는 간단한 Stub 클래스
+     */
+    private static class UserIdsRequestStub {
+        private final List<Long> userIds;
+
+        public UserIdsRequestStub(List<Long> userIds) {
+            this.userIds = userIds;
+        }
+
+        public List<Long> getUserIds() {
+            return userIds;
+        }
+    }
+}

--- a/src/test/java/com/ssafy/BlueStrongMountain/controller/ProblemFilterControllerTest.java
+++ b/src/test/java/com/ssafy/BlueStrongMountain/controller/ProblemFilterControllerTest.java
@@ -1,0 +1,149 @@
+package com.ssafy.BlueStrongMountain.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import com.ssafy.BlueStrongMountain.dto.ProblemDto;
+import com.ssafy.BlueStrongMountain.dto.FilteredProblemsResponse;
+import com.ssafy.BlueStrongMountain.dto.ProblemFilterRequest;
+import com.ssafy.BlueStrongMountain.service.ProblemFetchService;
+import com.ssafy.BlueStrongMountain.service.ProblemFilterService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@SpringBootTest
+public class ProblemFilterControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private ProblemFetchService fetchService;
+
+    @Mock
+    private ProblemFilterService filterService;
+
+    @InjectMocks
+    private ProblemFilterController problemFilterController;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(problemFilterController).build();
+    }
+
+    @Test
+    void testFilterWithModeNormal() throws Exception {
+        // Given
+        ProblemFilterRequest request = new ProblemFilterRequest(
+                "normal",                    // mode
+                new ArrayList<>(),            // problemIds
+                0,                            // difficultyFrom
+                20,                           // difficultyTo
+                new ArrayList<>(),            // tags
+                null,                         // minSolvers (null로 전달할 수 있음)
+                false                         // unsolved
+        );
+        List<ProblemDto> mockProblems = new ArrayList<>();
+        mockProblems.add(new ProblemDto(1000L, "Problem 1", 10, new ArrayList<>(), 100, "2024-11-01", 5));
+
+        when(fetchService.fetchBaseProblems(any(Long.class), any(Boolean.class))).thenReturn(mockProblems);
+        when(filterService.applyFilters(any(List.class), any(ProblemFilterRequest.class))).thenReturn(mockProblems);
+
+        // When & Then
+        mockMvc.perform(post("/api/v1/groups/1/problems/filter")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\n" +
+                                "  \"mode\": \"normal\",\n" +
+                                "  \"problemIds\": [],\n" +
+                                "  \"difficultyFrom\": 0,\n" +
+                                "  \"difficultyTo\": 20,\n" +
+                                "  \"tags\": [],\n" +
+                                "  \"minSolvers\": null,\n" +
+                                "  \"unsolved\": false\n" +
+                                "}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].id").value(1000))
+                .andExpect(jsonPath("$.data[0].title").value("Problem 1"))
+                .andExpect(jsonPath("$.data[0].difficulty").value(10));
+    }
+
+    @Test
+    void testFilterWithModeReview() throws Exception {
+        // Given
+        ProblemFilterRequest request = new ProblemFilterRequest(
+                "review",                    // mode
+                new ArrayList<>(),            // problemIds
+                0,                            // difficultyFrom
+                30,                           // difficultyTo
+                new ArrayList<>(),            // tags
+                null,                         // minSolvers (null로 전달할 수 있음)
+                false                         // unsolved
+        );
+        List<ProblemDto> mockProblems = new ArrayList<>();
+        mockProblems.add(new ProblemDto(1500L, "Problem 2", 15, new ArrayList<>(), 200, "2024-11-02", 10));
+
+        when(fetchService.fetchReviewProblems(any(Long.class))).thenReturn(mockProblems);
+        when(filterService.applyFilters(any(List.class), any(ProblemFilterRequest.class))).thenReturn(mockProblems);
+
+        // When & Then
+        mockMvc.perform(post("/api/v1/groups/1/problems/filter")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\n" +
+                                "  \"mode\": \"review\",\n" +
+                                "  \"problemIds\": [],\n" +
+                                "  \"difficultyFrom\": 0,\n" +
+                                "  \"difficultyTo\": 30,\n" +
+                                "  \"tags\": [],\n" +
+                                "  \"minSolvers\": null,\n" +
+                                "  \"unsolved\": false\n" +
+                                "}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].id").value(1500))
+                .andExpect(jsonPath("$.data[0].title").value("Problem 2"))
+                .andExpect(jsonPath("$.data[0].difficulty").value(15));
+    }
+
+    @Test
+    void testFilterWithEmptyRequest() throws Exception {
+        // Given
+        ProblemFilterRequest request = new ProblemFilterRequest(
+                "normal",                    // mode
+                new ArrayList<>(),            // problemIds
+                0,                            // difficultyFrom
+                20,                           // difficultyTo
+                new ArrayList<>(),            // tags
+                null,                         // minSolvers (null로 전달할 수 있음)
+                false                         // unsolved
+        );
+        List<ProblemDto> mockProblems = new ArrayList<>();
+        when(fetchService.fetchBaseProblems(any(Long.class), any(Boolean.class))).thenReturn(mockProblems);
+        when(filterService.applyFilters(any(List.class), any(ProblemFilterRequest.class))).thenReturn(mockProblems);
+
+        // When & Then
+        mockMvc.perform(post("/api/v1/groups/1/problems/filter")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\n" +
+                                "  \"mode\": \"normal\",\n" +
+                                "  \"problemIds\": [],\n" +
+                                "  \"difficultyFrom\": 0,\n" +
+                                "  \"difficultyTo\": 20,\n" +
+                                "  \"tags\": [],\n" +
+                                "  \"minSolvers\": null,\n" +
+                                "  \"unsolved\": false\n" +
+                                "}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+}


### PR DESCRIPTION
이슈번호 :  https://github.com/cheonggangsan/BlueStrongMountain_backend/issues/7
## ✅ 이 PR에서 구현한 내용

### 1) **그룹 생성 기능 구현 (`GroupService#createGroup`)**

- 제목, 설명, visibility(PRIVATE), ownerId 기반으로 Group 생성
- 생성된 그룹에 대해 `OWNER` Role의 UserGroup 자동 등록
- 요청에서 넘어온 `managerIds`, `memberIds`도 각각 MANAGER, MEMBER 로 자동 생성

### 2) **내 그룹 조회 및 검색 (`findMyGroups`, `searchMyGroups`)**

- requester가 속한 groupId 목록 조회
- 각 group의 총 memberCount를 계산 후 정렬(updatedAt 내림차순)
- 키워드 검색 시 title 기반으로 필터링

### 3) **그룹 수정 기능 (`updateGroup`)**

- 제목, 설명 변경
- Owner 권한 검증 후 업데이트

### 4) **그룹 소유자 변경 기능 (`changeOwner`)**

- owner → newOwner로 변경
- oldOwner는 MEMBER로 강등
- newOwner는 OWNER Role로 승격
- 소유권 이전 가능 여부는 `GroupAuthorityService` 통해 검증

---

### 5) **그룹 멤버 관리 기능 (GroupMemberService)**

### ✔ 매니저 추가 (`addManager`)

- Owner 권한 확인
- 해당 사용자의 기존 역할 확인 후 MANAGER로 변경
- OWNER는 매니저로 바꿀 수 없도록 예외 처리

### ✔ 매니저 삭제 (`removeManagers`)

- 여러 명의 managerIds 처리 가능
- OWNER 자신 제거 불가
- MANAGER → MEMBER 로 변경

### ✔ 멤버 추가 (`addMember`)

- manager or owner 권한 검증
- 기존에 참여 중인 유저라면 중복 추가 불가

### ✔ 멤버 삭제 (`removeMember`)

- owner 권한 검증
- owner 자신 삭제 불가
- MEMBER/ MANAGER 제거 가능

### ✔ 그룹 나가기 (`leaveGroup`)

- OWNER는 나갈 수 없음
- 나머지 Role은 정상적으로 그룹 탈퇴

---

## 📂 변경된 주요 컴포넌트/모듈

### 1) **GroupServiceImpl**

- 그룹 생성, 조회, 검색, 수정, owner 변경 등 핵심 비즈니스 로직 담당
- 그룹 생성 시 manager/member 존재 시 배정 포함
- GroupValidator / GroupAuthorityService 포함해 입력 값 + 권한 검증

### 2) **GroupMemberServiceImpl**

- 매니저/멤버 추가 및 삭제, 그룹 나가기 등 멤버십 로직 처리
- OWNER / MANAGER 권한 구분 처리
- CannotRemoveOwnerException, UserNotInGroupException 예외 처리 포함

### 3) **UserGroupRepository**

- 유저‒그룹 관계 조회/저장/삭제
- (userId, groupId) 단건 조회로 권한 검증 처리

### 4) **GroupRepository**

- 그룹 단건 조회 및 리스트 조회
- findByIds 를 통해 requester가 속한 그룹 전체 조회

### 5) **DTO**

- `GroupCreateRequest`
- `GroupUpdateRequest`
- `GroupSummaryDto`
- 역할 변경 / 멤버 조회 관련 데이터 포함

### 6) **Validator / AuthorityService**

- GroupValidator: 그룹 생성/수정 요청 검증
- GroupAuthorityService: Owner, Manager 권한 검증, Owner 교체 가능여부 등

---

## 🧪 동작 흐름/사용 시나리오

### 1) 그룹 생성 시나리오

요청:

```json
POST /api/v1/groups
{
  "title": "청강산 알고리즘 스터디",
  "description": "심화 알고리즘 스터디",
  "managerIds": [2, 3],
  "memberIds": [4, 5]
}

```

흐름:

1. Controller → createGroup 호출
2. GroupValidator로 title/description 검증
3. Group.create() → GroupRepository.save()
4. OWNER(UserGroup) 생성
5. managerIds → MANAGER role로 저장
6. memberIds → MEMBER role로 저장
7. 생성된 groupId 반환

---

### 2) 그룹 목록 조회

1. userGroupRepository.findByUserId(requesterId)
2. groupId 목록으로 groupRepository.findByIds()
3. 각각 memberCount 계산 후 GroupSummaryDto 구성
4. updatedAt 기준 내림차순 정렬 후 반환

---

### 3) 그룹 수정 흐름

1. requesterId가 OWNER인지 GroupAuthorityService.validateOwner로 검증
2. title, description 업데이트
3. groupRepository.save()

---

### 4) 그룹 소유자 변경 흐름

1. owner → newOwnerId 변경 가능 여부 검증
2. Group.changeOwner 호출
3. oldOwner UserGroup role → MEMBER
4. newOwner UserGroup role → OWNER

---

### 5) 멤버 관리 흐름

### 매니저 추가

```
Owner → 특정 memberId 매니저 승격
```

### 매니저 제거

```
Owner → 여러 명의 managerIds 모두 MEMBER로 변경
```

### 멤버 추가

```
Manager/Owner → 새로운 userId MEMBER로 초대

```

### 멤버 제거

```
Owner → MEMBER/ MANAGER 모두 제거 가능
Owner 본인은 제거 불가

```

### 그룹 나가기

```
OWNER → 나가기 금지
MANAGER / MEMBER → 정상 탈퇴 가능

```

---

## 💡 기타

- Owner가 유일한 관리자이므로, Owner의 역할 변경/삭제는 항상 예외 처리
- GroupAuthorityService는 권한 문제를 도메인 외부에서 일관성 있게 관리하기 위해 분리됨
- GroupVisibility는 현재 PRIVATE이 기본값이나 PUBLIC 확장 가능

- 추후 확장 포인트
    - 그룹 초대 코드 생성 기능
    - 멤버 승인(PENDING) 기능
    - 그룹 활동 내역 로그(history) 저장 기능

close : https://github.com/cheonggangsan/BlueStrongMountain_backend/issues/7