### PR TITLE
[BST-17] user 로그인, 회원가입, 정보조회, 수정 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,9 +29,15 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.5'
-    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
-    compileOnly 'org.projectlombok:lombok'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+
+	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/ssafy/BlueStrongMountain/auth/JwtProvider.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/auth/JwtProvider.java
@@ -1,0 +1,59 @@
+package com.ssafy.BlueStrongMountain.auth;
+
+import com.ssafy.BlueStrongMountain.domain.User;
+import com.ssafy.BlueStrongMountain.domain.UserRole;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.stereotype.Component;
+import io.jsonwebtoken.io.Decoders;
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtProvider {
+    private static final String SECRET =
+            "VGhpcy1pcy1yYW5kb20tc2VjcmV0LWtleS1mb3ItQlNULUFwcA==";
+
+    // Access Token: 30분
+    private static final long ACCESS_TOKEN_VALIDITY_MS = 30 * 60 * 1000;
+
+    // Refresh Token: 14일
+    private static final long REFRESH_TOKEN_VALIDITY_MS = 14L * 24 * 60 * 60 * 1000;
+
+    private Key key;
+
+    @PostConstruct
+    public void init(){
+        byte[] keyBytes = Decoders.BASE64.decode(SECRET);
+        key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String generateAccessToken(User user) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + ACCESS_TOKEN_VALIDITY_MS);
+
+        return Jwts.builder()
+                .setSubject(String.valueOf(user.getId()))
+                .claim("email", user.getEmail())
+                .claim("username", user.getUsername())
+                .claim("role", UserRole.USER.name())
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+    public String generateRefreshToken(User user) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + REFRESH_TOKEN_VALIDITY_MS);
+
+        return Jwts.builder()
+                .setSubject(String.valueOf(user.getId()))
+                .claim("type", "refresh")
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/config/PasswordEncoderConfig.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/config/PasswordEncoderConfig.java
@@ -1,0 +1,15 @@
+package com.ssafy.BlueStrongMountain.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+
+@Configuration
+public class PasswordEncoderConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/config/SecurityConfig.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/config/SecurityConfig.java
@@ -1,0 +1,45 @@
+package com.ssafy.BlueStrongMountain.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf().disable()
+                .cors().and()   // ★ CorsConfig가 Security에도 적용되도록 활성화
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll() // ★ preflight 허용
+                        .anyRequest().permitAll()
+                );
+
+        return http.build();
+    }
+
+    // ★ Security가 사용할 CORS 설정 Bean
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOriginPatterns(List.of("*"));
+        config.setAllowedMethods(List.of("GET","POST","PUT","PATCH","DELETE","OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+
+        return source;
+    }
+}
+

--- a/src/main/java/com/ssafy/BlueStrongMountain/controller/AuthController.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/controller/AuthController.java
@@ -1,0 +1,37 @@
+package com.ssafy.BlueStrongMountain.controller;
+
+import com.ssafy.BlueStrongMountain.dto.*;
+import com.ssafy.BlueStrongMountain.service.AuthService;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@AllArgsConstructor
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest req) {
+        return ResponseEntity.ok(authService.login(req));
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<RegisterResponse> register(@RequestBody RegisterRequest req){
+
+        //test
+        System.out.println("!!!!!!!!!register user");
+        System.out.println(req.toString());
+
+        return ResponseEntity.ok(authService.register(req));
+    }
+
+    @GetMapping("/duplicate/username")
+    public ResponseEntity<UsernameDuplicateResponse> dup(
+            @RequestParam String username
+    ) {
+        return ResponseEntity.ok(authService.checkUsername(username));
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/controller/UserController.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/controller/UserController.java
@@ -1,0 +1,47 @@
+package com.ssafy.BlueStrongMountain.controller;
+
+import com.ssafy.BlueStrongMountain.dto.BaseResponse;
+import com.ssafy.BlueStrongMountain.dto.ChangePasswordRequest;
+import com.ssafy.BlueStrongMountain.dto.ChangeUsernameRequest;
+import com.ssafy.BlueStrongMountain.dto.UserInfoResponse;
+import com.ssafy.BlueStrongMountain.service.UserService;
+import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@AllArgsConstructor
+public class UserController {
+    private final UserService userService;
+
+    @GetMapping("/{id}")
+    public ResponseEntity<UserInfoResponse> get(@PathVariable Long id) {
+        return ResponseEntity.ok(userService.getUser(id));
+    }
+
+    @PatchMapping("/{id}/username")
+    public ResponseEntity<BaseResponse> changeName(
+            @PathVariable Long id,
+            @RequestBody ChangeUsernameRequest req
+            ) {
+        userService.changeUsername(id, req.getUsername());
+    //FIXME response type 따로 만들어야 하는지?
+        return ResponseEntity.ok(BaseResponse.ok());
+    }
+
+    @PatchMapping("/{id}/password")
+    public ResponseEntity<BaseResponse> changePw(
+            @PathVariable Long id,
+            @RequestBody ChangePasswordRequest req
+            ){
+        userService.changePassword(id, req.getPassword());
+        return ResponseEntity.ok(BaseResponse.ok());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<BaseResponse> delete(@PathVariable Long id){
+        userService.deleteUser(id);
+        return ResponseEntity.ok(BaseResponse.ok());
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/domain/User.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/domain/User.java
@@ -1,0 +1,65 @@
+package com.ssafy.BlueStrongMountain.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@Getter
+public class User {
+
+    private final Long id;
+    private final String email;
+    private final String password;
+    private final String username;
+    private final String baekjoonHandle;
+    private final UserStatus status;
+    private final UserRole role;
+    private final String refreshToken;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public static User createNew(String email, String hashedPw, String username, String baekjoon){
+        LocalDateTime now = LocalDateTime.now();
+        return new User(
+                null,
+                email,
+                hashedPw,
+                username,
+                baekjoon,
+                UserStatus.ACTIVE,
+                UserRole.USER,
+                null,
+                now,
+                now
+        );
+    }
+    public User withId(Long id){
+        return new User(id, email, password, username, baekjoonHandle,
+                status, role, refreshToken, createdAt, updatedAt);
+    }
+    public User withUsername(String newUsername) {
+        LocalDateTime now = LocalDateTime.now();
+        return new User(id, email, password, newUsername, baekjoonHandle, status, role, refreshToken, createdAt, now);
+    }
+
+    public User withPassword(String newHashedPw) {
+        LocalDateTime now = LocalDateTime.now();
+        return new User(id, email, newHashedPw, username, baekjoonHandle, status, role, refreshToken, createdAt, now);
+    }
+
+    public User withRefreshToken(String newToken) {
+        LocalDateTime now = LocalDateTime.now();
+        return new User(id, email, password, username, baekjoonHandle, status, role, newToken, createdAt, now);
+    }
+
+    public User inactive() {
+        LocalDateTime now = LocalDateTime.now();
+        return new User(id, email, password, username, baekjoonHandle, UserStatus.INACTIVE, role, null, createdAt, now);
+    }
+
+
+
+
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/domain/UserRole.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/domain/UserRole.java
@@ -1,0 +1,6 @@
+package com.ssafy.BlueStrongMountain.domain;
+
+public enum UserRole {
+    USER,
+    ADMIN
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/domain/UserStatus.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/domain/UserStatus.java
@@ -1,0 +1,7 @@
+package com.ssafy.BlueStrongMountain.domain;
+
+public enum UserStatus {
+    ACTIVE,
+    INACTIVE,
+    BANNED
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/ChangePasswordRequest.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/ChangePasswordRequest.java
@@ -1,0 +1,10 @@
+package com.ssafy.BlueStrongMountain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class ChangePasswordRequest {
+    private final String password;
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/ChangeUsernameRequest.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/ChangeUsernameRequest.java
@@ -1,0 +1,10 @@
+package com.ssafy.BlueStrongMountain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class ChangeUsernameRequest {
+    private final String username;
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/LoginRequest.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/LoginRequest.java
@@ -1,0 +1,13 @@
+package com.ssafy.BlueStrongMountain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@AllArgsConstructor
+@Getter
+@ToString
+public class LoginRequest {
+    private final String email;
+    private final String password;
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/LoginResponse.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/LoginResponse.java
@@ -1,0 +1,16 @@
+package com.ssafy.BlueStrongMountain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@AllArgsConstructor
+@Getter
+@ToString
+public class LoginResponse {
+    private final Long userId;
+    private final String email;
+    private final String username;
+    private final String token;
+    private final String refreshToken;
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/RegisterRequest.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/RegisterRequest.java
@@ -1,0 +1,15 @@
+package com.ssafy.BlueStrongMountain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@AllArgsConstructor
+@Getter
+@ToString
+public class RegisterRequest {
+    private final String email;
+    private final String password;
+    private final String username;
+    private final String baekjoon;
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/RegisterResponse.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/RegisterResponse.java
@@ -1,0 +1,15 @@
+package com.ssafy.BlueStrongMountain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@AllArgsConstructor
+@Getter
+@ToString
+public class RegisterResponse {
+    private final Long userId;
+    private final String email;
+    private final String username;
+    private final String status;
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/UserInfoResponse.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/UserInfoResponse.java
@@ -13,6 +13,7 @@ public class UserInfoResponse {
     private final Long userId;
     private final String email;
     private final String username;
+    private final String baekjoonHandle;
     private final String status;
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/UserInfoResponse.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/UserInfoResponse.java
@@ -1,0 +1,19 @@
+package com.ssafy.BlueStrongMountain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@Getter
+@ToString
+public class UserInfoResponse {
+    private final Long userId;
+    private final String email;
+    private final String username;
+    private final String status;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/UsernameDuplicateResponse.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/UsernameDuplicateResponse.java
@@ -1,0 +1,11 @@
+package com.ssafy.BlueStrongMountain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class UsernameDuplicateResponse {
+    private final String username;
+    private final boolean duplicated;
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/exception/AuthenticationFailedException.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/exception/AuthenticationFailedException.java
@@ -1,0 +1,4 @@
+package com.ssafy.BlueStrongMountain.exception;
+
+public class AuthenticationFailedException extends RuntimeException{
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/exception/EmailAlreadyExistsException.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/exception/EmailAlreadyExistsException.java
@@ -1,0 +1,4 @@
+package com.ssafy.BlueStrongMountain.exception;
+
+public class EmailAlreadyExistsException extends RuntimeException{
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/exception/InvalidPasswordException.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/exception/InvalidPasswordException.java
@@ -1,0 +1,4 @@
+package com.ssafy.BlueStrongMountain.exception;
+
+public class InvalidPasswordException extends RuntimeException{
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/exception/UserHasGroupException.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/exception/UserHasGroupException.java
@@ -1,0 +1,4 @@
+package com.ssafy.BlueStrongMountain.exception;
+
+public class UserHasGroupException extends RuntimeException{
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/exception/UserNotFoundException.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/exception/UserNotFoundException.java
@@ -1,0 +1,4 @@
+package com.ssafy.BlueStrongMountain.exception;
+
+public class UserNotFoundException extends RuntimeException{
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/exception/UserStatusNotActiveException.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/exception/UserStatusNotActiveException.java
@@ -1,0 +1,4 @@
+package com.ssafy.BlueStrongMountain.exception;
+
+public class UserStatusNotActiveException extends RuntimeException{
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/exception/UsernameAlreadyExistsException.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/exception/UsernameAlreadyExistsException.java
@@ -1,0 +1,4 @@
+package com.ssafy.BlueStrongMountain.exception;
+
+public class UsernameAlreadyExistsException extends RuntimeException{
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/InMemoryUserRepository.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/InMemoryUserRepository.java
@@ -1,0 +1,59 @@
+package com.ssafy.BlueStrongMountain.repository;
+
+import com.ssafy.BlueStrongMountain.domain.User;
+import org.springframework.stereotype.Repository;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Repository
+public class InMemoryUserRepository implements UserRepository{
+
+    private final AtomicLong seq = new AtomicLong(0);
+    private final Map<Long, User> store = new HashMap<>();
+    private final Map<String, Long> emailIndex = new HashMap<>();
+    private final Map<String, Long> usernameIndex = new HashMap<>();
+
+    @Override
+    public User save(User user) {
+        Long id = user.getId();
+        if(id == null) id = seq.incrementAndGet();
+
+        User savedUser = user.withId(id);
+        store.put(id, savedUser);
+
+        emailIndex.put(savedUser.getEmail(), id);
+        usernameIndex.put(savedUser.getUsername(), id);
+
+        return savedUser;
+    }
+
+    @Override
+    public Optional<User> findByEmail(String email) {
+        Long id = emailIndex.get(email);
+        if(id == null) return Optional.empty();
+        return Optional.ofNullable(store.get(id));
+    }
+
+    @Override
+    public Optional<User> findById(Long id) {
+        return Optional.ofNullable(store.get(id));
+    }
+
+    @Override
+    public Optional<User> findByUsername(String username) {
+        Long id = usernameIndex.get(username);
+        if (id == null) return Optional.empty();
+        return Optional.ofNullable(store.get(id));
+    }
+
+    @Override
+    public void delete(Long id) {
+        User user = store.remove(id);
+        if (user == null) return;
+        emailIndex.remove(user.getEmail());
+        usernameIndex.remove(user.getUsername());
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/UserRepository.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.ssafy.BlueStrongMountain.repository;
+
+import com.ssafy.BlueStrongMountain.domain.User;
+
+import java.util.Optional;
+
+public interface UserRepository {
+    User save(User user);
+    Optional<User> findByEmail(String email);
+    Optional<User> findById(Long id);
+    Optional<User> findByUsername(String username);
+    void delete(Long id);
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/AuthService.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/AuthService.java
@@ -1,0 +1,9 @@
+package com.ssafy.BlueStrongMountain.service;
+
+import com.ssafy.BlueStrongMountain.dto.*;
+
+public interface AuthService {
+    public RegisterResponse register(RegisterRequest req);
+    public LoginResponse login(LoginRequest req);
+    public UsernameDuplicateResponse checkUsername(String username);
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/AuthServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/AuthServiceImpl.java
@@ -1,0 +1,75 @@
+package com.ssafy.BlueStrongMountain.service;
+
+import com.ssafy.BlueStrongMountain.auth.JwtProvider;
+import com.ssafy.BlueStrongMountain.domain.User;
+import com.ssafy.BlueStrongMountain.domain.UserStatus;
+import com.ssafy.BlueStrongMountain.dto.*;
+import com.ssafy.BlueStrongMountain.exception.*;
+import com.ssafy.BlueStrongMountain.repository.UserRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class AuthServiceImpl implements AuthService{
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public RegisterResponse register(RegisterRequest req) {
+        //email, username 중복검증, password 검증
+        userRepository.findByEmail(req.getEmail())
+                .ifPresent(u -> {throw new EmailAlreadyExistsException();
+                });
+        userRepository.findByUsername(req.getUsername())
+                .ifPresent(u -> {throw new UsernameAlreadyExistsException();
+                });
+        if(req.getPassword().length() < 8){
+            throw new InvalidPasswordException();
+        }
+
+        User createdUser = User.createNew(
+                req.getEmail(),
+                passwordEncoder.encode(req.getPassword()),
+                req.getUsername(),
+                req.getBaekjoon()
+        );
+
+        User savedUser = userRepository.save(createdUser);
+
+        return new RegisterResponse(savedUser.getId(), savedUser.getEmail(),
+                savedUser.getUsername(), savedUser.getStatus().name());
+    }
+
+    @Override
+    public LoginResponse login(LoginRequest req) {
+        User foundUser = userRepository.findByEmail(req.getEmail())
+                .orElseThrow(AuthenticationFailedException::new);
+
+        boolean match = passwordEncoder.matches(req.getPassword()
+                , foundUser.getPassword());
+        if(!match) throw new AuthenticationFailedException();
+
+        if(foundUser.getStatus() != UserStatus.ACTIVE){
+            throw new UserStatusNotActiveException();
+        }
+
+        String accessToken = jwtProvider.generateAccessToken(foundUser);
+        String refreshToken = jwtProvider.generateRefreshToken(foundUser);
+
+        User savedUser = foundUser.withRefreshToken(refreshToken);
+        userRepository.save(savedUser);
+
+        return new LoginResponse(savedUser.getId(), savedUser.getEmail(),
+                savedUser.getUsername(), accessToken, refreshToken);
+    }
+
+    @Override
+    public UsernameDuplicateResponse checkUsername(String username) {
+
+        boolean isSameName = userRepository.findByUsername(username).isPresent();
+        return new UsernameDuplicateResponse(username, isSameName);
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/UserService.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/UserService.java
@@ -1,0 +1,10 @@
+package com.ssafy.BlueStrongMountain.service;
+
+import com.ssafy.BlueStrongMountain.dto.UserInfoResponse;
+
+public interface UserService {
+    public UserInfoResponse getUser(Long userId);
+    public void changeUsername(Long userId, String newName);
+    public void changePassword(Long userId, String newPw);
+    public void deleteUser(Long userId);
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/UserServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/UserServiceImpl.java
@@ -24,6 +24,7 @@ public class UserServiceImpl implements UserService{
                 .orElseThrow(UserNotFoundException::new);
         return new UserInfoResponse(
                 user.getId(), user.getEmail(), user.getUsername(),
+                user.getBaekjoonHandle(),
                 user.getStatus().name(), user.getCreatedAt(), user.getUpdatedAt()
         );
     }

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/UserServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/UserServiceImpl.java
@@ -1,0 +1,66 @@
+package com.ssafy.BlueStrongMountain.service;
+
+import com.ssafy.BlueStrongMountain.domain.User;
+import com.ssafy.BlueStrongMountain.dto.UserInfoResponse;
+import com.ssafy.BlueStrongMountain.exception.InvalidPasswordException;
+import com.ssafy.BlueStrongMountain.exception.UserHasGroupException;
+import com.ssafy.BlueStrongMountain.exception.UserNotFoundException;
+import com.ssafy.BlueStrongMountain.exception.UsernameAlreadyExistsException;
+import com.ssafy.BlueStrongMountain.repository.UserRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class UserServiceImpl implements UserService{
+    private final UserRepository userRepository;
+    private final GroupService groupService;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public UserInfoResponse getUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+        return new UserInfoResponse(
+                user.getId(), user.getEmail(), user.getUsername(),
+                user.getStatus().name(), user.getCreatedAt(), user.getUpdatedAt()
+        );
+    }
+
+    @Override
+    public void changeUsername(Long userId, String newName) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+        userRepository.findByUsername(newName)
+                .ifPresent(u -> {throw new UsernameAlreadyExistsException();});
+
+        User updatedUser = user.withUsername(newName);
+        userRepository.save(updatedUser);
+    }
+
+    @Override
+    public void changePassword(Long userId, String newPw) {
+        if(newPw.length() < 8) throw new InvalidPasswordException();
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
+        User updatedUser = user.withPassword(passwordEncoder.encode(newPw));
+        userRepository.save(updatedUser);
+    }
+
+    @Override
+    public void deleteUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
+        //group에 속해 있으면 예외처리
+        if(!groupService.findMyGroups(userId).isEmpty()){
+            throw new UserHasGroupException();
+        }
+
+        User updatedUser = user.inactive();
+        userRepository.save(updatedUser);
+    }
+}

--- a/src/test/java/com/ssafy/BlueStrongMountain/controller/AuthControllerTest.java
+++ b/src/test/java/com/ssafy/BlueStrongMountain/controller/AuthControllerTest.java
@@ -1,0 +1,140 @@
+package com.ssafy.BlueStrongMountain.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ssafy.BlueStrongMountain.domain.UserStatus;
+import com.ssafy.BlueStrongMountain.dto.LoginRequest;
+import com.ssafy.BlueStrongMountain.dto.LoginResponse;
+import com.ssafy.BlueStrongMountain.dto.RegisterRequest;
+import com.ssafy.BlueStrongMountain.dto.RegisterResponse;
+import com.ssafy.BlueStrongMountain.dto.UsernameDuplicateResponse;
+import com.ssafy.BlueStrongMountain.service.AuthService;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+
+import org.springframework.http.MediaType;
+
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+
+@WebMvcTest(AuthController.class)
+// ★ Security 비활성화
+@AutoConfigureMockMvc(addFilters = false)
+class AuthControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockitoBean
+    AuthService authService;
+
+
+    // -------------------------------------------------------------------------
+    // LOGIN
+    // -------------------------------------------------------------------------
+    @Test
+    @DisplayName("POST /api/v1/auth/login - 로그인 성공")
+    void login_success() throws Exception {
+
+        LoginRequest req = new LoginRequest(
+                "test@gmail.com",
+                "test1234"
+        );
+
+        LoginResponse res = new LoginResponse(
+                1L,
+                "test@gmail.com",
+                "tester",
+                "ACCESS_TOKEN",
+                "REFRESH_TOKEN"
+        );
+
+        //given(authService.login(req)).willReturn(res);
+        given(authService.login(Mockito.any(LoginRequest.class)))
+                .willReturn(res);
+
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value(1L))
+                .andExpect(jsonPath("$.email").value("test@gmail.com"))
+                .andExpect(jsonPath("$.username").value("tester"));
+//                .andExpect(jsonPath("$.token").value("ACCESS_TOKEN"))
+//                .andExpect(jsonPath("$.refreshToken").value("REFRESH_TOKEN"));
+    }
+
+
+
+    // -------------------------------------------------------------------------
+    // REGISTER
+    // -------------------------------------------------------------------------
+    @Test
+    @DisplayName("POST /api/v1/auth/register - 회원가입 성공")
+    void register_success() throws Exception {
+
+        RegisterRequest req = new RegisterRequest(
+                "test@gmail.com",
+                "test1234",
+                "tester",
+                "baekjoonID"
+        );
+
+        RegisterResponse res = new RegisterResponse(
+                1L,
+                "test@gmail.com",
+                "tester",
+                UserStatus.ACTIVE.name()
+        );
+
+        //given(authService.register(req)).willReturn(res);
+        given(authService.register(Mockito.any(RegisterRequest.class)))
+                .willReturn(res);
+
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value(1L))
+                .andExpect(jsonPath("$.email").value("test@gmail.com"))
+                .andExpect(jsonPath("$.username").value("tester"));
+    }
+
+
+
+    // -------------------------------------------------------------------------
+    // USERNAME DUPLICATE CHECK
+    // -------------------------------------------------------------------------
+    @Test
+    @DisplayName("GET /api/v1/auth/duplicate/username - username 중복 체크 성공")
+    void duplicate_username_success() throws Exception {
+
+        String username = "tester";
+
+        UsernameDuplicateResponse res = new UsernameDuplicateResponse(username, false);
+
+        given(authService.checkUsername(username)).willReturn(res);
+
+        mockMvc.perform(get("/api/v1/auth/duplicate/username")
+                        .param("username", username))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.duplicated").value(false));
+    }
+}

--- a/src/test/java/com/ssafy/BlueStrongMountain/controller/UserControllerTest.java
+++ b/src/test/java/com/ssafy/BlueStrongMountain/controller/UserControllerTest.java
@@ -1,0 +1,124 @@
+package com.ssafy.BlueStrongMountain.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ssafy.BlueStrongMountain.domain.UserStatus;
+import com.ssafy.BlueStrongMountain.dto.ChangePasswordRequest;
+import com.ssafy.BlueStrongMountain.dto.ChangeUsernameRequest;
+import com.ssafy.BlueStrongMountain.dto.UserInfoResponse;
+import com.ssafy.BlueStrongMountain.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+
+import org.springframework.http.MediaType;
+
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(UserController.class)
+//spring security 비활성화
+@AutoConfigureMockMvc(addFilters = false)
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private UserService userService;
+
+
+    @Test
+    @DisplayName("GET /api/v1/users/{id} - 유저 조회 성공")
+    void getUser_success() throws Exception {
+        // given
+        Long userId = 1L;
+        UserInfoResponse mockResponse = new UserInfoResponse(
+                userId,
+                "test@gmail.com",
+                "tester",
+                "baekjoonID",
+                UserStatus.ACTIVE.name(),
+                LocalDateTime.now(),
+                LocalDateTime.now()
+        );
+
+        given(userService.getUser(userId)).willReturn(mockResponse);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/users/{id}", userId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value(userId))
+                .andExpect(jsonPath("$.email").value("test@gmail.com"))
+                .andExpect(jsonPath("$.username").value("tester"))
+                .andExpect(jsonPath("$.baekjoonHandle").value("baekjoonID"));
+    }
+
+
+
+    @Test
+    @DisplayName("PATCH /api/v1/users/{id}/username - 이름 변경 성공")
+    void changeUsername_success() throws Exception {
+        // given
+        Long userId = 1L;
+        ChangeUsernameRequest req = new ChangeUsernameRequest("newName");
+
+        doNothing().when(userService).changeUsername(userId, "newName");
+
+        // when & then
+        mockMvc.perform(patch("/api/v1/users/{id}/username", userId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+    }
+
+
+
+    @Test
+    @DisplayName("PATCH /api/v1/users/{id}/password - 비밀번호 변경 성공")
+    void changePassword_success() throws Exception {
+        // given
+        Long userId = 1L;
+        ChangePasswordRequest req = new ChangePasswordRequest("newPassword123");
+
+        doNothing().when(userService).changePassword(userId, "newPassword123");
+
+        // when & then
+        mockMvc.perform(patch("/api/v1/users/{id}/password", userId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+    }
+
+
+
+    @Test
+    @DisplayName("DELETE /api/v1/users/{id} - 유저 삭제 성공")
+    void deleteUser_success() throws Exception {
+        // given
+        Long userId = 1L;
+        doNothing().when(userService).deleteUser(userId);
+
+        // when & then
+        mockMvc.perform(delete("/api/v1/users/{id}", userId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+    }
+}


### PR DESCRIPTION
이슈 번호: https://github.com/cheonggangsan/BlueStrongMountain_backend/issues/17


# 📂 구현 내용

## 1. User 단일 조회 API

- **GET /api/v1/users/{id}**
- 특정 사용자 정보를 반환
- Response: `UserInfoResponse`
- 예외 처리: 존재하지 않는 사용자일 경우 사용자 정의 예외 반환

## 2. Username 변경 API

- **PATCH /api/v1/users/{id}/username**
- Request: `ChangeUsernameRequest`
- 비즈니스 로직:
    - username 중복 여부 확인
    - 본인 여부 / 권한 검증
    - 정상 변경 시 `BaseResponse.success()` 반환

## 3. Password 변경 API

- **PATCH /api/v1/users/{id}/password**
- Request: `ChangePasswordRequest`
- 비즈니스 로직:
    - 기존 비밀번호 검증
    - 새로운 비밀번호 암호화 후 저장
    - `BaseResponse.success()` 반환

## 4. RegisterRequest의 누락 필드 추가 (`baekjoon`)

- 회원가입 시 필요한 baekjoon 필드 누락 문제 해결
- Request DTO 수정:
    
    ```json
    {
      "email": "user@example.com",
      "password": "12345678",
      "username": "홍길동",
      "baekjoon": "ssalassala"
    }
    
    ```
    

---

# 🧪 테스트

- Controller 단위 테스트(MockMvc) 작성
    - GET /users/{id} 정상 조회
    - PATCH /users/{id}/username 정상 변경 및 유효성 검증
    - PATCH /users/{id}/password 비밀번호 불일치 시 실패 시나리오
- Service 단위 테스트
    - findUser
    - changeUsername
    - changePassword

---

# 💡 주요 고려 사항

- username 변경은 중복 체크 + 예외 반환 추가
- password 변경 시 반드시 기존 비밀번호 검증
- DTO와 Entity 간 분리 원칙 준수
- Setter 사용 없이 불변성 유지 (User 정적 팩토리 / 변경 메서드 사용)

---

# 🔧 변경된 파일 목록

(예시)

- `UserController.java`
- `UserService.java`
- `UserServiceImpl.java`
- `UserRepository.java`
- `ChangeUsernameRequest.java`
- `ChangePasswordRequest.java`
- `UserInfoResponse.java`
- `RegisterRequest.java` (baekjoon 필드 추가)

---

