### PR TITLE
[BST-21] mapper 활용 db 연결

### DIFF
--- a/src/main/java/com/ssafy/BlueStrongMountain/config/MyBatisConfig.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/config/MyBatisConfig.java
@@ -1,0 +1,9 @@
+package com.ssafy.BlueStrongMountain.config;
+
+import org.mybatis.spring.annotation.MapperScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@MapperScan(basePackages = "com.ssafy.BlueStrongMountain.repository.mapper")
+public class MyBatisConfig {
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/controller/UserSolutionController.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/controller/UserSolutionController.java
@@ -1,0 +1,75 @@
+package com.ssafy.BlueStrongMountain.controller;
+
+import com.ssafy.BlueStrongMountain.domain.UserSolution;
+import com.ssafy.BlueStrongMountain.dto.UserSolutionCreateRequest;
+import com.ssafy.BlueStrongMountain.dto.UserSolutionResponse;
+import com.ssafy.BlueStrongMountain.service.UserSolutionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/v1/user-solutions")
+@RequiredArgsConstructor
+public class UserSolutionController {
+
+    private final UserSolutionService userSolutionService;
+
+    /** 문제 해결 기록 저장 */
+    @PostMapping
+    public ResponseEntity<UserSolutionResponse> save(@RequestBody UserSolutionCreateRequest req) {
+
+        UserSolution solution = UserSolution.create(
+                req.getUserId(),
+                req.getProblemId(),
+                LocalDateTime.now()
+        );
+
+        userSolutionService.save(solution);
+
+        return ResponseEntity.ok(
+                new UserSolutionResponse(
+                        solution.getUserId(),
+                        solution.getProblemId(),
+                        solution.getSolvedAt().toString()
+                )
+        );
+    }
+
+    /** 특정 유저가 푼 문제 목록 조회 */
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<List<Long>> findByUser(@PathVariable Long userId) {
+        List<Long> solvedIds = userSolutionService.findSolvedProblemIds(userId);
+        return ResponseEntity.ok(solvedIds);
+    }
+
+    /** 특정 문제를 푼 유저 목록 조회 */
+    @GetMapping("/problem/{problemId}")
+    public ResponseEntity<List<UserSolutionResponse>> findByProblem(@PathVariable Long problemId) {
+        List<UserSolution> list = userSolutionService.findByProblemId(problemId);
+
+        List<UserSolutionResponse> result = list.stream()
+                .map(s -> new UserSolutionResponse(
+                        s.getUserId(),
+                        s.getProblemId(),
+                        s.getSolvedAt().toString()
+                ))
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(result);
+    }
+
+    /** 특정 유저가 특정 문제를 풀었는지 여부 조회 */
+    @GetMapping("/check")
+    public ResponseEntity<Boolean> hasSolved(
+            @RequestParam Long userId,
+            @RequestParam Long problemId
+    ) {
+        return ResponseEntity.ok(userSolutionService.hasSolved(userId, problemId));
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/domain/Board.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/domain/Board.java
@@ -1,13 +1,8 @@
 package com.ssafy.BlueStrongMountain.domain;
 
 import lombok.Getter;
-
 import java.time.LocalDateTime;
 
-
-import lombok.Getter;
-
-import java.time.LocalDateTime;
 
 @Getter
 public final class Board {

--- a/src/main/java/com/ssafy/BlueStrongMountain/domain/BoardProblem.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/domain/BoardProblem.java
@@ -1,7 +1,6 @@
 package com.ssafy.BlueStrongMountain.domain;
 
 import lombok.Getter;
-
 import java.time.LocalDateTime;
 
 @Getter

--- a/src/main/java/com/ssafy/BlueStrongMountain/domain/Problem.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/domain/Problem.java
@@ -1,0 +1,43 @@
+package com.ssafy.BlueStrongMountain.domain;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class Problem {
+
+    private final Long id;
+    private final String title;
+    private final Integer difficulty;
+    private final Integer acceptedUserCount;
+    private final LocalDateTime lastSyncedAt;
+
+    public Problem(Long id,
+                   String title,
+                   Integer difficulty,
+                   Integer acceptedUserCount,
+                   LocalDateTime lastSyncedAt) {
+        this.id = id;
+        this.title = title;
+        this.difficulty = difficulty;
+        this.acceptedUserCount = acceptedUserCount;
+        this.lastSyncedAt = lastSyncedAt;
+    }
+
+    public Problem withTitle(String title) {
+        return new Problem(this.id, title, this.difficulty, this.acceptedUserCount, this.lastSyncedAt);
+    }
+
+    public Problem withDifficulty(Integer difficulty) {
+        return new Problem(this.id, this.title, difficulty, this.acceptedUserCount, this.lastSyncedAt);
+    }
+
+    public Problem withAcceptedUserCount(Integer acceptedUserCount) {
+        return new Problem(this.id, this.title, this.difficulty, acceptedUserCount, this.lastSyncedAt);
+    }
+
+    public Problem withLastSyncedAt(LocalDateTime lastSyncedAt) {
+        return new Problem(this.id, this.title, this.difficulty, this.acceptedUserCount, lastSyncedAt);
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/domain/ProblemTag.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/domain/ProblemTag.java
@@ -1,0 +1,17 @@
+package com.ssafy.BlueStrongMountain.domain;
+
+import lombok.Getter;
+
+@Getter
+public class ProblemTag {
+
+    private final Long id;
+    private final Long problemId;
+    private final Long tagId;
+
+    public ProblemTag(Long id, Long problemId, Long tagId) {
+        this.id = id;
+        this.problemId = problemId;
+        this.tagId = tagId;
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/domain/Tag.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/domain/Tag.java
@@ -1,0 +1,19 @@
+package com.ssafy.BlueStrongMountain.domain;
+
+import lombok.Getter;
+
+@Getter
+public class Tag {
+
+    private final Long id;
+    private final String name;
+
+    public Tag(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public Tag withName(String name) {
+        return new Tag(this.id, name);
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/domain/UserSolution.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/domain/UserSolution.java
@@ -1,0 +1,35 @@
+package com.ssafy.BlueStrongMountain.domain;
+
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+public class UserSolution {
+
+    private final Long id;
+    private final Long userId;
+    private final Long problemId;
+    private final LocalDateTime solvedAt;
+    private final LocalDateTime createdAt;
+
+    private UserSolution(Long id, Long userId, Long problemId,
+                         LocalDateTime solvedAt, LocalDateTime createdAt) {
+        this.id = id;
+        this.userId = userId;
+        this.problemId = problemId;
+        this.solvedAt = solvedAt;
+        this.createdAt = createdAt;
+    }
+    public static UserSolution create(Long userId, Long problemId, LocalDateTime now) {
+        return new UserSolution(
+                null,
+                userId,
+                problemId,
+                now,
+                now
+        );
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/ProblemDto.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/ProblemDto.java
@@ -3,27 +3,17 @@ package com.ssafy.BlueStrongMountain.dto;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
-@AllArgsConstructor
+@NoArgsConstructor
 @Getter
+@ToString
 public class ProblemDto {
     private Long id;
     private String title;
     private Integer difficulty;
     private List<String> tags;
     private Integer acceptedUserCount;
-    private String registeredAt;
-    private Integer reviewCount;
-    @Override
-    public String toString() {
-        return "ProblemDto{" +
-                "id=" + id +
-                ", title='" + title + '\'' +
-                ", difficulty=" + difficulty +
-                ", tags=" + tags +
-                ", acceptedUserCount=" + acceptedUserCount +
-                ", registeredAt='" + registeredAt + '\'' +
-                ", reviewCount=" + reviewCount +
-                '}';
-    }
+    private String updatedAt;
 }

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/UserSolutionCreateRequest.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/UserSolutionCreateRequest.java
@@ -1,0 +1,9 @@
+package com.ssafy.BlueStrongMountain.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UserSolutionCreateRequest {
+    private Long userId;
+    private Long problemId;
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/UserSolutionResponse.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/UserSolutionResponse.java
@@ -1,0 +1,12 @@
+package com.ssafy.BlueStrongMountain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserSolutionResponse {
+    private Long userId;
+    private Long problemId;
+    private String solvedAt;
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/BoardProblemRepositoryImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/BoardProblemRepositoryImpl.java
@@ -1,0 +1,30 @@
+package com.ssafy.BlueStrongMountain.repository;
+
+import com.ssafy.BlueStrongMountain.domain.BoardProblem;
+import com.ssafy.BlueStrongMountain.repository.mapper.BoardProblemMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class BoardProblemRepositoryImpl implements BoardProblemRepository{
+
+    private final BoardProblemMapper mapper;
+
+    @Override
+    public void deleteByBoardId(Long boardId) {
+        mapper.deleteByBoardId(boardId);
+    }
+
+    @Override
+    public void saveAll(List<BoardProblem> problems) {
+        mapper.insertAll(problems);
+    }
+
+    @Override
+    public List<BoardProblem> findByBoardId(Long boardId) {
+        return mapper.findByBoardId(boardId);
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/BoardRepositoryImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/BoardRepositoryImpl.java
@@ -1,0 +1,41 @@
+package com.ssafy.BlueStrongMountain.repository;
+
+import com.ssafy.BlueStrongMountain.domain.Board;
+import com.ssafy.BlueStrongMountain.repository.mapper.BoardMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class BoardRepositoryImpl implements BoardRepository{
+    private final BoardMapper mapper;
+
+    @Override
+    public Board save(Board board) {
+        if(board.getId() == null) {
+            mapper.insert(board);
+        }
+        else{
+            mapper.update(board);
+        }
+        return board;
+    }
+
+    @Override
+    public Optional<Board> findById(Long boardId) {
+        return Optional.ofNullable(mapper.findById(boardId));
+    }
+
+    @Override
+    public List<Board> findByGroupId(Long groupId) {
+        return mapper.findByGroupId(groupId);
+    }
+
+    @Override
+    public void delete(Long boardId) {
+        mapper.delete(boardId);
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/GroupRepository.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/GroupRepository.java
@@ -5,9 +5,8 @@ import java.util.List;
 import java.util.Optional;
 
 public interface GroupRepository {
-    List<Long> findUserIdsByGroupId(Long groupId);
-    List<Long> findGroupSolvedProblems(Long groupId);
-    List<Long> findUsersSolvedProblems(Long groupId);
+//    List<Long> findUserIdsByGroupId(Long groupId);
+//    List<Long> findGroupSolvedProblems(Long groupId);
 
     Group save(Group group);
     Optional<Group> findById(Long groupId);

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/GroupRepositoryImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/GroupRepositoryImpl.java
@@ -1,0 +1,45 @@
+package com.ssafy.BlueStrongMountain.repository;
+
+import com.ssafy.BlueStrongMountain.domain.Group;
+import com.ssafy.BlueStrongMountain.repository.mapper.GroupMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class GroupRepositoryImpl implements GroupRepository{
+    private final GroupMapper mapper;
+
+    @Override
+    public Group save(Group group) {
+        if (group.getId() == null) {
+            mapper.insert(group);
+            return group;
+        }
+        mapper.update(group);
+        return group;
+    }
+
+    @Override
+    public Optional<Group> findById(Long groupId) {
+        return mapper.findById(groupId);
+    }
+
+    @Override
+    public List<Group> findByIds(List<Long> groupIds) {
+        return mapper.findByIds(groupIds);
+    }
+
+    @Override
+    public List<Group> findByTitleLike(String titleKeyword) {
+        return mapper.findByTitleLike(titleKeyword);
+    }
+
+    @Override
+    public void deleteById(Long groupId) {
+        mapper.delete(groupId);
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/InMemoryBoardProblemRepository.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/InMemoryBoardProblemRepository.java
@@ -1,62 +1,62 @@
-package com.ssafy.BlueStrongMountain.repository;
-
-import com.ssafy.BlueStrongMountain.domain.BoardProblem;
-import com.ssafy.BlueStrongMountain.repository.BoardProblemRepository;
-import org.springframework.stereotype.Repository;
-
-import java.util.*;
-import java.util.concurrent.atomic.AtomicLong;
-
-@Repository
-public class InMemoryBoardProblemRepository implements BoardProblemRepository {
-    // id 기반 저장소
-    private final Map<Long, BoardProblem> store = new HashMap<>();
-    // 보드 단위 조회 인덱스
-    private final Map<Long, List<Long>> boardIndex = new HashMap<>();
-    private final AtomicLong sequence = new AtomicLong(1);
-    @Override
-    public void deleteByBoardId(Long boardId) {
-
-        List<Long> problemIds = boardIndex.getOrDefault(boardId, new ArrayList<>());
-
-        // id 리스트 삭제
-        for (Long id : problemIds) {
-            store.remove(id);
-        }
-
-        // 인덱스 삭제
-        boardIndex.remove(boardId);
-    }
-
-    @Override
-    public void saveAll(List<BoardProblem> problems) {
-
-        for (BoardProblem p : problems) {
-            Long newId = sequence.getAndIncrement();
-
-            // Immutable 객체이므로 assignId로 새 객체 생성
-            BoardProblem saved = p.assignId(newId);
-            store.put(newId, saved);
-
-            // boardId 인덱스 갱신
-            boardIndex.computeIfAbsent(saved.getBoardId(), k -> new ArrayList<>())
-                    .add(newId);
-        }
-    }
-
-    @Override
-    public List<BoardProblem> findByBoardId(Long boardId) {
-
-        List<Long> ids = boardIndex.getOrDefault(boardId, Collections.emptyList());
-
-        List<BoardProblem> result = new ArrayList<>();
-        for (Long id : ids) {
-            BoardProblem bp = store.get(id);
-            if (bp != null) {
-                result.add(bp);
-            }
-        }
-
-        return result;
-    }
-}
+//package com.ssafy.BlueStrongMountain.repository;
+//
+//import com.ssafy.BlueStrongMountain.domain.BoardProblem;
+//import com.ssafy.BlueStrongMountain.repository.BoardProblemRepository;
+//import org.springframework.stereotype.Repository;
+//
+//import java.util.*;
+//import java.util.concurrent.atomic.AtomicLong;
+//
+////@Repository
+//public class InMemoryBoardProblemRepository implements BoardProblemRepository {
+//    // id 기반 저장소
+//    private final Map<Long, BoardProblem> store = new HashMap<>();
+//    // 보드 단위 조회 인덱스
+//    private final Map<Long, List<Long>> boardIndex = new HashMap<>();
+//    private final AtomicLong sequence = new AtomicLong(1);
+//    @Override
+//    public void deleteByBoardId(Long boardId) {
+//
+//        List<Long> problemIds = boardIndex.getOrDefault(boardId, new ArrayList<>());
+//
+//        // id 리스트 삭제
+//        for (Long id : problemIds) {
+//            store.remove(id);
+//        }
+//
+//        // 인덱스 삭제
+//        boardIndex.remove(boardId);
+//    }
+//
+//    @Override
+//    public void saveAll(List<BoardProblem> problems) {
+//
+//        for (BoardProblem p : problems) {
+//            Long newId = sequence.getAndIncrement();
+//
+//            // Immutable 객체이므로 assignId로 새 객체 생성
+//            BoardProblem saved = p.assignId(newId);
+//            store.put(newId, saved);
+//
+//            // boardId 인덱스 갱신
+//            boardIndex.computeIfAbsent(saved.getBoardId(), k -> new ArrayList<>())
+//                    .add(newId);
+//        }
+//    }
+//
+//    @Override
+//    public List<BoardProblem> findByBoardId(Long boardId) {
+//
+//        List<Long> ids = boardIndex.getOrDefault(boardId, Collections.emptyList());
+//
+//        List<BoardProblem> result = new ArrayList<>();
+//        for (Long id : ids) {
+//            BoardProblem bp = store.get(id);
+//            if (bp != null) {
+//                result.add(bp);
+//            }
+//        }
+//
+//        return result;
+//    }
+//}

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/InMemoryBoardRepository.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/InMemoryBoardRepository.java
@@ -1,42 +1,42 @@
-package com.ssafy.BlueStrongMountain.repository;
-
-import com.ssafy.BlueStrongMountain.domain.Board;
-import org.springframework.stereotype.Repository;
-
-import java.util.*;
-import java.util.concurrent.atomic.AtomicLong;
-
-@Repository
-public class InMemoryBoardRepository implements BoardRepository{
-    private final Map<Long, Board> store = new HashMap<>();
-    private final AtomicLong sequence = new AtomicLong(1);
-
-    @Override
-    public Board save(Board board) {
-        Long id = board.getId() == null ? sequence.incrementAndGet() : board.getId();
-        Board toSave = board.getId() == null ? board.assignId(id) : board;
-        store.put(id, toSave);
-        return toSave;
-    }
-
-    @Override
-    public Optional<Board> findById(Long boardId) {
-        return Optional.ofNullable(store.get(boardId));
-    }
-
-    @Override
-    public List<Board> findByGroupId(Long groupId) {
-        List<Board> result = new ArrayList<>();
-        for (Board board : store.values()) {
-            if (board.getGroupId().equals(groupId)) {
-                result.add(board);
-            }
-        }
-        return result;
-    }
-
-    @Override
-    public void delete(Long boardId) {
-        store.remove(boardId);
-    }
-}
+//package com.ssafy.BlueStrongMountain.repository;
+//
+//import com.ssafy.BlueStrongMountain.domain.Board;
+//import org.springframework.stereotype.Repository;
+//
+//import java.util.*;
+//import java.util.concurrent.atomic.AtomicLong;
+//
+////@Repository
+//public class InMemoryBoardRepository implements BoardRepository{
+//    private final Map<Long, Board> store = new HashMap<>();
+//    private final AtomicLong sequence = new AtomicLong(1);
+//
+//    @Override
+//    public Board save(Board board) {
+//        Long id = board.getId() == null ? sequence.incrementAndGet() : board.getId();
+//        Board toSave = board.getId() == null ? board.assignId(id) : board;
+//        store.put(id, toSave);
+//        return toSave;
+//    }
+//
+//    @Override
+//    public Optional<Board> findById(Long boardId) {
+//        return Optional.ofNullable(store.get(boardId));
+//    }
+//
+//    @Override
+//    public List<Board> findByGroupId(Long groupId) {
+//        List<Board> result = new ArrayList<>();
+//        for (Board board : store.values()) {
+//            if (board.getGroupId().equals(groupId)) {
+//                result.add(board);
+//            }
+//        }
+//        return result;
+//    }
+//
+//    @Override
+//    public void delete(Long boardId) {
+//        store.remove(boardId);
+//    }
+//}

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/InMemoryUserGroupRepository.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/InMemoryUserGroupRepository.java
@@ -1,139 +1,139 @@
-package com.ssafy.BlueStrongMountain.repository;
-
-import com.ssafy.BlueStrongMountain.domain.GroupRole;
-import com.ssafy.BlueStrongMountain.domain.UserGroup;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
-import org.springframework.stereotype.Repository;
-
-@Repository
-public class InMemoryUserGroupRepository implements UserGroupRepository{
-
-    // Key: groupId
-    private final Map<Long, List<UserGroup>> groups = new ConcurrentHashMap<>();
-
-    // Key: userId
-    private final Map<Long, List<UserGroup>> users = new ConcurrentHashMap<>();
-
-    @Override
-    public UserGroup save(UserGroup userGroup) {
-//        groups.computeIfAbsent(userGroup.getGroupId(), k -> new ArrayList<>()).add(userGroup);
-//        users.computeIfAbsent(userGroup.getUserId(), k -> new ArrayList<>()).add(userGroup);
-
-        Long userId = userGroup.getUserId();
-        Long groupId = userGroup.getGroupId();
-
-        List<UserGroup> groupList = groups.getOrDefault(groupId, new ArrayList<>());
-        groupList.removeIf(ug -> ug.getUserId().equals(userId));
-
-        List<UserGroup> userList = users.getOrDefault(userId, new ArrayList<>());
-        userList.removeIf(ug -> ug.getGroupId().equals(groupId));
-
-        groupList.add(userGroup);
-        userList.add(userGroup);
-
-        groups.put(groupId, groupList);
-        users.put(userId, userList);
-
-//        //test
+//package com.ssafy.BlueStrongMountain.repository;
 //
-//        List<UserGroup> members = findByGroupIdAndRole(groupId, GroupRole.MEMBER);
-//        List<UserGroup> managers = findByGroupIdAndRole(groupId, GroupRole.MANAGER);
+//import com.ssafy.BlueStrongMountain.domain.GroupRole;
+//import com.ssafy.BlueStrongMountain.domain.UserGroup;
+//import java.util.ArrayList;
+//import java.util.List;
+//import java.util.Map;
+//import java.util.Optional;
+//import java.util.concurrent.ConcurrentHashMap;
+//import org.springframework.stereotype.Repository;
 //
-//        System.out.println("get members!!!!!!!!!!!1");
-//        for(UserGroup ug : members)
-//            System.out.println(ug.getUserId());
+////@Repository
+//public class InMemoryUserGroupRepository implements UserGroupRepository{
 //
-//        System.out.println("get managers!!!!!!!!!!!!");
-//        for(UserGroup ug : managers){
-//            System.out.println(ug.getUserId());
+//    // Key: groupId
+//    private final Map<Long, List<UserGroup>> groups = new ConcurrentHashMap<>();
+//
+//    // Key: userId
+//    private final Map<Long, List<UserGroup>> users = new ConcurrentHashMap<>();
+//
+//    @Override
+//    public UserGroup save(UserGroup userGroup) {
+////        groups.computeIfAbsent(userGroup.getGroupId(), k -> new ArrayList<>()).add(userGroup);
+////        users.computeIfAbsent(userGroup.getUserId(), k -> new ArrayList<>()).add(userGroup);
+//
+//        Long userId = userGroup.getUserId();
+//        Long groupId = userGroup.getGroupId();
+//
+//        List<UserGroup> groupList = groups.getOrDefault(groupId, new ArrayList<>());
+//        groupList.removeIf(ug -> ug.getUserId().equals(userId));
+//
+//        List<UserGroup> userList = users.getOrDefault(userId, new ArrayList<>());
+//        userList.removeIf(ug -> ug.getGroupId().equals(groupId));
+//
+//        groupList.add(userGroup);
+//        userList.add(userGroup);
+//
+//        groups.put(groupId, groupList);
+//        users.put(userId, userList);
+//
+////        //test
+////
+////        List<UserGroup> members = findByGroupIdAndRole(groupId, GroupRole.MEMBER);
+////        List<UserGroup> managers = findByGroupIdAndRole(groupId, GroupRole.MANAGER);
+////
+////        System.out.println("get members!!!!!!!!!!!1");
+////        for(UserGroup ug : members)
+////            System.out.println(ug.getUserId());
+////
+////        System.out.println("get managers!!!!!!!!!!!!");
+////        for(UserGroup ug : managers){
+////            System.out.println(ug.getUserId());
+////        }
+////
+////        //test
+//
+//        return userGroup;
+//    }
+//
+//    //user
+//    @Override
+//    public List<UserGroup> findByUserId(Long userId) {
+//        return users.getOrDefault(userId, List.of());
+//    }
+//
+//    @Override
+//    public List<UserGroup> findByGroupId(Long groupId) {
+//        return groups.getOrDefault(groupId, List.of());
+//    }
+//
+//    @Override
+//    public Optional<UserGroup> findByUserIdAndGroupId(Long userId, Long groupId) {
+//        List<UserGroup> list = groups.get(groupId);
+//
+//        if (list == null) {
+//            return Optional.empty();
 //        }
 //
-//        //test
-
-        return userGroup;
-    }
-
-    //user
-    @Override
-    public List<UserGroup> findByUserId(Long userId) {
-        return users.getOrDefault(userId, List.of());
-    }
-
-    @Override
-    public List<UserGroup> findByGroupId(Long groupId) {
-        return groups.getOrDefault(groupId, List.of());
-    }
-
-    @Override
-    public Optional<UserGroup> findByUserIdAndGroupId(Long userId, Long groupId) {
-        List<UserGroup> list = groups.get(groupId);
-
-        if (list == null) {
-            return Optional.empty();
-        }
-
-        for (UserGroup ug : list) {
-            if (ug.getUserId().equals(userId)) {
-                return Optional.of(ug);
-            }
-        }
-
-        return Optional.empty();
-    }
-
-    @Override
-    public void deleteByUserIdAndGroupId(Long userId, Long groupId) {
-        List<UserGroup> list = groups.get(groupId);
-        if (list != null) {
-            list.removeIf(ug -> ug.getUserId().equals(userId));
-        }
-
-        List<UserGroup> userList = users.get(userId);
-        if (userList != null) {
-            userList.removeIf(ug -> ug.getGroupId().equals(groupId));
-        }
-    }
-
-    @Override
-    public void deleteByGroupIdAndUserIdIn(Long groupId, List<Long> userIds) {
-        List<UserGroup> list = groups.get(groupId);
-
-        if (list != null) {
-            list.removeIf(ug -> userIds.contains(ug.getUserId()));
-        }
-
-        for (Long userId : userIds) {
-            List<UserGroup> userList = users.get(userId);
-            if (userList != null) {
-                userList.removeIf(ug -> ug.getGroupId().equals(groupId));
-            }
-        }
-    }
-
-    @Override
-    public int countByGroupId(Long groupId) {
-        return findByGroupIdAndRole(groupId, GroupRole.MEMBER).size();
-    }
-
-    @Override
-    public List<UserGroup> findByGroupIdAndRole(Long groupId, GroupRole role) {
-        List<UserGroup> result = new ArrayList<>();
-        List<UserGroup> list = groups.get(groupId);
-
-        if (list == null) {
-            return result;
-        }
-
-        for (UserGroup ug : list) {
-            if (ug.getRole() == role) {
-                result.add(ug);
-            }
-        }
-
-        return result;
-    }
-}
+//        for (UserGroup ug : list) {
+//            if (ug.getUserId().equals(userId)) {
+//                return Optional.of(ug);
+//            }
+//        }
+//
+//        return Optional.empty();
+//    }
+//
+//    @Override
+//    public void deleteByUserIdAndGroupId(Long userId, Long groupId) {
+//        List<UserGroup> list = groups.get(groupId);
+//        if (list != null) {
+//            list.removeIf(ug -> ug.getUserId().equals(userId));
+//        }
+//
+//        List<UserGroup> userList = users.get(userId);
+//        if (userList != null) {
+//            userList.removeIf(ug -> ug.getGroupId().equals(groupId));
+//        }
+//    }
+//
+//    @Override
+//    public void deleteByGroupIdAndUserIdIn(Long groupId, List<Long> userIds) {
+//        List<UserGroup> list = groups.get(groupId);
+//
+//        if (list != null) {
+//            list.removeIf(ug -> userIds.contains(ug.getUserId()));
+//        }
+//
+//        for (Long userId : userIds) {
+//            List<UserGroup> userList = users.get(userId);
+//            if (userList != null) {
+//                userList.removeIf(ug -> ug.getGroupId().equals(groupId));
+//            }
+//        }
+//    }
+//
+//    @Override
+//    public int countByGroupId(Long groupId) {
+//        return findByGroupIdAndRole(groupId, GroupRole.MEMBER).size();
+//    }
+//
+//    @Override
+//    public List<UserGroup> findByGroupIdAndRole(Long groupId, GroupRole role) {
+//        List<UserGroup> result = new ArrayList<>();
+//        List<UserGroup> list = groups.get(groupId);
+//
+//        if (list == null) {
+//            return result;
+//        }
+//
+//        for (UserGroup ug : list) {
+//            if (ug.getRole() == role) {
+//                result.add(ug);
+//            }
+//        }
+//
+//        return result;
+//    }
+//}

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/InMemoryUserRepository.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/InMemoryUserRepository.java
@@ -1,59 +1,59 @@
-package com.ssafy.BlueStrongMountain.repository;
-
-import com.ssafy.BlueStrongMountain.domain.User;
-import org.springframework.stereotype.Repository;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicLong;
-
-//@Repository
-public class InMemoryUserRepository implements UserRepository{
-
-    private final AtomicLong seq = new AtomicLong(0);
-    private final Map<Long, User> store = new HashMap<>();
-    private final Map<String, Long> emailIndex = new HashMap<>();
-    private final Map<String, Long> usernameIndex = new HashMap<>();
-
-    @Override
-    public User save(User user) {
-        Long id = user.getId();
-        if(id == null) id = seq.incrementAndGet();
-
-        User savedUser = user.withId(id);
-        store.put(id, savedUser);
-
-        emailIndex.put(savedUser.getEmail(), id);
-        usernameIndex.put(savedUser.getUsername(), id);
-
-        return savedUser;
-    }
-
-    @Override
-    public Optional<User> findByEmail(String email) {
-        Long id = emailIndex.get(email);
-        if(id == null) return Optional.empty();
-        return Optional.ofNullable(store.get(id));
-    }
-
-    @Override
-    public Optional<User> findById(Long id) {
-        return Optional.ofNullable(store.get(id));
-    }
-
-    @Override
-    public Optional<User> findByUsername(String username) {
-        Long id = usernameIndex.get(username);
-        if (id == null) return Optional.empty();
-        return Optional.ofNullable(store.get(id));
-    }
-
-    @Override
-    public void delete(Long id) {
-        User user = store.remove(id);
-        if (user == null) return;
-        emailIndex.remove(user.getEmail());
-        usernameIndex.remove(user.getUsername());
-    }
-}
+//package com.ssafy.BlueStrongMountain.repository;
+//
+//import com.ssafy.BlueStrongMountain.domain.User;
+//import org.springframework.stereotype.Repository;
+//
+//import java.util.HashMap;
+//import java.util.Map;
+//import java.util.Optional;
+//import java.util.concurrent.atomic.AtomicLong;
+//
+////@Repository
+//public class InMemoryUserRepository implements UserRepository{
+//
+//    private final AtomicLong seq = new AtomicLong(0);
+//    private final Map<Long, User> store = new HashMap<>();
+//    private final Map<String, Long> emailIndex = new HashMap<>();
+//    private final Map<String, Long> usernameIndex = new HashMap<>();
+//
+//    @Override
+//    public User save(User user) {
+//        Long id = user.getId();
+//        if(id == null) id = seq.incrementAndGet();
+//
+//        User savedUser = user.withId(id);
+//        store.put(id, savedUser);
+//
+//        emailIndex.put(savedUser.getEmail(), id);
+//        usernameIndex.put(savedUser.getUsername(), id);
+//
+//        return savedUser;
+//    }
+//
+//    @Override
+//    public Optional<User> findByEmail(String email) {
+//        Long id = emailIndex.get(email);
+//        if(id == null) return Optional.empty();
+//        return Optional.ofNullable(store.get(id));
+//    }
+//
+//    @Override
+//    public Optional<User> findById(Long id) {
+//        return Optional.ofNullable(store.get(id));
+//    }
+//
+//    @Override
+//    public Optional<User> findByUsername(String username) {
+//        Long id = usernameIndex.get(username);
+//        if (id == null) return Optional.empty();
+//        return Optional.ofNullable(store.get(id));
+//    }
+//
+//    @Override
+//    public void delete(Long id) {
+//        User user = store.remove(id);
+//        if (user == null) return;
+//        emailIndex.remove(user.getEmail());
+//        usernameIndex.remove(user.getUsername());
+//    }
+//}

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/InMemoryUserRepository.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/InMemoryUserRepository.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 
-@Repository
+//@Repository
 public class InMemoryUserRepository implements UserRepository{
 
     private final AtomicLong seq = new AtomicLong(0);

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/MockGroupRepository.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/MockGroupRepository.java
@@ -1,109 +1,109 @@
-package com.ssafy.BlueStrongMountain.repository;
-
-import com.ssafy.BlueStrongMountain.domain.Group;
-import com.ssafy.BlueStrongMountain.dto.GroupProblemDto;
-import com.ssafy.BlueStrongMountain.dto.UserSolvedDto;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Collectors;
-import org.springframework.stereotype.Repository;
-
-@Repository
-public class MockGroupRepository implements GroupRepository{
-    private static final List<GroupProblemDto> MOCK_GROUP_SOLVED_PROBLEMS = List.of(
-            new GroupProblemDto(1L, 1003L, 1),
-            new GroupProblemDto(1L, 1005L, 2),
-            new GroupProblemDto(1L, 1009L, 3)
-    );
-    private static final List<UserSolvedDto> MOCK_EACH_USERS_SOLVED_PROBLEMS = List.of(
-            new UserSolvedDto(1L, 1003L, 1L),
-            new UserSolvedDto(2L, 1003L, 1L),
-            new UserSolvedDto(1L, 1005L, 1L),
-            new UserSolvedDto(1L, 1409L, 1L),
-            new UserSolvedDto(2L, 2004L, 1L)
-    );
-
-
-    @Override
-    public List<Long> findUserIdsByGroupId(Long groupId) {
-        return List.of(1L, 2L);
-    }
-
-    @Override
-    public List<Long> findGroupSolvedProblems(Long groupId) {
-        return MOCK_GROUP_SOLVED_PROBLEMS.stream()
-                .map(GroupProblemDto::getProblemId)
-                .collect(Collectors.toList());
-    }
-
-    @Override
-    public List<Long> findUsersSolvedProblems(Long groupId) {
-        return MOCK_EACH_USERS_SOLVED_PROBLEMS.stream()
-                .map(UserSolvedDto::getProblemId)
-                .distinct()
-                .collect(Collectors.toList());
-    }
-    private final Map<Long, Group> store = new ConcurrentHashMap<>();
-    private final AtomicLong sequence = new AtomicLong(1);
-
-
-    @Override
-    public Group save(Group group) {
-        if (group.getId() == null) {
-            Long id = sequence.getAndIncrement();
-            setId(group, id);
-        }
-
-        store.put(group.getId(), group);
-        return group;
-    }
-
-    @Override
-    public Optional<Group> findById(final Long groupId) {
-        return Optional.ofNullable(store.get(groupId));
-    }
-
-    // 안필요할 수도?
-    @Override
-    public List<Group> findByIds(final List<Long> groupIds) {
-        List<Group> result = new ArrayList<>();
-
-        for (Long id : groupIds) {
-            if (store.containsKey(id)) {
-                result.add(store.get(id));
-            }
-        }
-        return result;
-    }
-
-    @Override
-    public List<Group> findByTitleLike(String titleKeyword) {
-        List<Group> result = new ArrayList<>();
-
-        for (Group group : store.values()) {
-            if (group.getTitle().toLowerCase().contains(titleKeyword.toLowerCase())) {
-                result.add(group);
-            }
-        }
-        return result;
-    }
-
-    @Override
-    public void deleteById(Long groupId) {
-        store.remove(groupId);
-    }
-    private void setId(final Group group, final Long id) {
-        try {
-            var field = Group.class.getDeclaredField("id");
-            field.setAccessible(true);
-            field.set(group, id);
-        } catch (Exception e) {
-            throw new RuntimeException("Reflection error: cannot set ID", e);
-        }
-    }
-
-}
+//package com.ssafy.BlueStrongMountain.repository;
+//
+//import com.ssafy.BlueStrongMountain.domain.Group;
+//import com.ssafy.BlueStrongMountain.dto.GroupProblemDto;
+//import com.ssafy.BlueStrongMountain.dto.UserSolvedDto;
+//import java.util.ArrayList;
+//import java.util.List;
+//import java.util.Map;
+//import java.util.Optional;
+//import java.util.concurrent.ConcurrentHashMap;
+//import java.util.concurrent.atomic.AtomicLong;
+//import java.util.stream.Collectors;
+//import org.springframework.stereotype.Repository;
+//
+////@Repository
+//public class MockGroupRepository implements GroupRepository{
+//    private static final List<GroupProblemDto> MOCK_GROUP_SOLVED_PROBLEMS = List.of(
+//            new GroupProblemDto(1L, 1003L, 1),
+//            new GroupProblemDto(1L, 1005L, 2),
+//            new GroupProblemDto(1L, 1009L, 3)
+//    );
+//    private static final List<UserSolvedDto> MOCK_EACH_USERS_SOLVED_PROBLEMS = List.of(
+//            new UserSolvedDto(1L, 1003L, 1L),
+//            new UserSolvedDto(2L, 1003L, 1L),
+//            new UserSolvedDto(1L, 1005L, 1L),
+//            new UserSolvedDto(1L, 1409L, 1L),
+//            new UserSolvedDto(2L, 2004L, 1L)
+//    );
+//
+//
+////    @Override
+////    public List<Long> findUserIdsByGroupId(Long groupId) {
+////        return List.of(1L, 2L);
+////    }
+////
+////    @Override
+////    public List<Long> findGroupSolvedProblems(Long groupId) {
+////        return MOCK_GROUP_SOLVED_PROBLEMS.stream()
+////                .map(GroupProblemDto::getProblemId)
+////                .collect(Collectors.toList());
+////    }
+//
+////    @Override
+////    public List<Long> findUsersSolvedProblems(Long groupId) {
+////        return MOCK_EACH_USERS_SOLVED_PROBLEMS.stream()
+////                .map(UserSolvedDto::getProblemId)
+////                .distinct()
+////                .collect(Collectors.toList());
+////    }
+//    private final Map<Long, Group> store = new ConcurrentHashMap<>();
+//    private final AtomicLong sequence = new AtomicLong(1);
+//
+//
+//    @Override
+//    public Group save(Group group) {
+//        if (group.getId() == null) {
+//            Long id = sequence.getAndIncrement();
+//            setId(group, id);
+//        }
+//
+//        store.put(group.getId(), group);
+//        return group;
+//    }
+//
+//    @Override
+//    public Optional<Group> findById(final Long groupId) {
+//        return Optional.ofNullable(store.get(groupId));
+//    }
+//
+//    // 안필요할 수도?
+//    @Override
+//    public List<Group> findByIds(final List<Long> groupIds) {
+//        List<Group> result = new ArrayList<>();
+//
+//        for (Long id : groupIds) {
+//            if (store.containsKey(id)) {
+//                result.add(store.get(id));
+//            }
+//        }
+//        return result;
+//    }
+//
+//    @Override
+//    public List<Group> findByTitleLike(String titleKeyword) {
+//        List<Group> result = new ArrayList<>();
+//
+//        for (Group group : store.values()) {
+//            if (group.getTitle().toLowerCase().contains(titleKeyword.toLowerCase())) {
+//                result.add(group);
+//            }
+//        }
+//        return result;
+//    }
+//
+//    @Override
+//    public void deleteById(Long groupId) {
+//        store.remove(groupId);
+//    }
+//    private void setId(final Group group, final Long id) {
+//        try {
+//            var field = Group.class.getDeclaredField("id");
+//            field.setAccessible(true);
+//            field.set(group, id);
+//        } catch (Exception e) {
+//            throw new RuntimeException("Reflection error: cannot set ID", e);
+//        }
+//    }
+//
+//}

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/MockProblemRepository.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/MockProblemRepository.java
@@ -1,37 +1,37 @@
-package com.ssafy.BlueStrongMountain.repository;
-
-import com.ssafy.BlueStrongMountain.dto.ProblemDto;
-import java.util.List;
-import java.util.Set;
-import org.springframework.stereotype.Repository;
-
-@Repository
-public class MockProblemRepository implements ProblemRepository {
-    private static final List<ProblemDto> MOCK_PROBLEM_DTOS = List.of(
-            new ProblemDto(1409L, "피보나치 수 1", 10, List.of("DP"), 1200, "2024-11-01", 2),
-            new ProblemDto(1508L, "DFS와 BFS", 11, List.of("Graph", "Breadth-first Search(BFS)", "DFS"), 3920, "2024-11-02", 1),
-            new ProblemDto(1000L, "A+B", 0, List.of("implementation"), 99999, "2024-11-03", 0),
-            new ProblemDto(1001L, "A-B", 0, List.of("dp"), 99999, "2024-11-04", 3),
-            new ProblemDto(1002L, "A*B", 0, List.of("dp"), 99999, "2024-11-05", 1),
-            new ProblemDto(1003L, "A/B", 0, List.of("Implementation"), 99999, "2024-11-06", 0),
-            new ProblemDto(1004L, "A%B", 0, List.of("Implementation"), 99999, "2024-11-07", 2),
-            new ProblemDto(1005L, "A&B", 0, List.of("bfs"), 99999, "2024-11-08", 4),
-            new ProblemDto(1006L, "A|B", 0, List.of("Implementation"), 99999, "2024-11-09", 0),
-            new ProblemDto(1007L, "A^B", 0, List.of("Implementation"), 99999, "2024-11-10", 2),
-            new ProblemDto(1008L, "A@B", 0, List.of("Implementation"), 99999, "2024-11-11", 1),
-            new ProblemDto(1009L, "A#B", 0, List.of("Implementation"), 99999, "2024-11-12", 5),
-            new ProblemDto(2000L, "이분 탐색 기본", 7, List.of("Binary Search"), 8000, "2024-11-13", 0),
-            new ProblemDto(2004L, "이것은 세상에서 제일 긴 문제 이름입니다. 테스트를 위해서 이렇게 일단 만들었습니다. 과연 어떻게 나올 것인가", 7, List.of("Binary Search"), 8000, "2024-11-14", 2)
-    );
-    @Override
-    public List<ProblemDto> findAll() {
-        return MOCK_PROBLEM_DTOS;
-    }
-
-    @Override
-    public List<ProblemDto> findByIdList(List<Long> ids) {
-        return MOCK_PROBLEM_DTOS.stream()
-                .filter(p -> ids.contains(p.getId()))
-                .toList();
-    }
-}
+//package com.ssafy.BlueStrongMountain.repository;
+//
+//import com.ssafy.BlueStrongMountain.dto.ProblemDto;
+//import java.util.List;
+//import java.util.Set;
+//import org.springframework.stereotype.Repository;
+//
+////@Repository
+//public class MockProblemRepository implements ProblemRepository {
+//    private static final List<ProblemDto> MOCK_PROBLEM_DTOS = List.of(
+//            new ProblemDto(1409L, "피보나치 수 1", 10, List.of("DP"), 1200, "2024-11-01", 2),
+//            new ProblemDto(1508L, "DFS와 BFS", 11, List.of("Graph", "Breadth-first Search(BFS)", "DFS"), 3920, "2024-11-02", 1),
+//            new ProblemDto(1000L, "A+B", 0, List.of("implementation"), 99999, "2024-11-03", 0),
+//            new ProblemDto(1001L, "A-B", 0, List.of("dp"), 99999, "2024-11-04", 3),
+//            new ProblemDto(1002L, "A*B", 0, List.of("dp"), 99999, "2024-11-05", 1),
+//            new ProblemDto(1003L, "A/B", 0, List.of("Implementation"), 99999, "2024-11-06", 0),
+//            new ProblemDto(1004L, "A%B", 0, List.of("Implementation"), 99999, "2024-11-07", 2),
+//            new ProblemDto(1005L, "A&B", 0, List.of("bfs"), 99999, "2024-11-08", 4),
+//            new ProblemDto(1006L, "A|B", 0, List.of("Implementation"), 99999, "2024-11-09", 0),
+//            new ProblemDto(1007L, "A^B", 0, List.of("Implementation"), 99999, "2024-11-10", 2),
+//            new ProblemDto(1008L, "A@B", 0, List.of("Implementation"), 99999, "2024-11-11", 1),
+//            new ProblemDto(1009L, "A#B", 0, List.of("Implementation"), 99999, "2024-11-12", 5),
+//            new ProblemDto(2000L, "이분 탐색 기본", 7, List.of("Binary Search"), 8000, "2024-11-13", 0),
+//            new ProblemDto(2004L, "이것은 세상에서 제일 긴 문제 이름입니다. 테스트를 위해서 이렇게 일단 만들었습니다. 과연 어떻게 나올 것인가", 7, List.of("Binary Search"), 8000, "2024-11-14", 2)
+//    );
+//    @Override
+//    public List<ProblemDto> findAll() {
+//        return MOCK_PROBLEM_DTOS;
+//    }
+//
+//    @Override
+//    public List<ProblemDto> findByIdList(List<Long> ids) {
+//        return MOCK_PROBLEM_DTOS.stream()
+//                .filter(p -> ids.contains(p.getId()))
+//                .toList();
+//    }
+//}

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/ProblemRepositoryImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/ProblemRepositoryImpl.java
@@ -1,0 +1,29 @@
+package com.ssafy.BlueStrongMountain.repository;
+
+import com.ssafy.BlueStrongMountain.dto.ProblemDto;
+import com.ssafy.BlueStrongMountain.repository.mapper.ProblemMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collections;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ProblemRepositoryImpl implements ProblemRepository {
+
+    private final ProblemMapper problemMapper;
+
+    @Override
+    public List<ProblemDto> findAll() {
+        return problemMapper.findAll();
+    }
+
+    @Override
+    public List<ProblemDto> findByIdList(List<Long> ids) {
+        if (ids == null || ids.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return problemMapper.findByIdList(ids);
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/UserGroupRepositoryImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/UserGroupRepositoryImpl.java
@@ -1,0 +1,59 @@
+package com.ssafy.BlueStrongMountain.repository;
+
+import com.ssafy.BlueStrongMountain.domain.GroupRole;
+import com.ssafy.BlueStrongMountain.domain.UserGroup;
+import com.ssafy.BlueStrongMountain.repository.mapper.UserGroupMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class UserGroupRepositoryImpl implements UserGroupRepository {
+
+    private final UserGroupMapper mapper;
+
+    @Override
+    public UserGroup save(UserGroup userGroup) {
+        mapper.insert(userGroup);
+        return userGroup;
+    }
+
+    @Override
+    public List<UserGroup> findByUserId(Long userId) {
+        return mapper.findByUserId(userId);
+    }
+
+    @Override
+    public List<UserGroup> findByGroupId(Long groupId) {
+        return mapper.findByGroupId(groupId);
+    }
+
+    @Override
+    public Optional<UserGroup> findByUserIdAndGroupId(Long userId, Long groupId) {
+        return mapper.findByUserIdAndGroupId(userId, groupId);
+    }
+
+    @Override
+    public void deleteByUserIdAndGroupId(Long userId, Long groupId) {
+        mapper.deleteByUserIdAndGroupId(userId, groupId);
+    }
+
+    @Override
+    public void deleteByGroupIdAndUserIdIn(Long groupId, List<Long> userIds) {
+        mapper.deleteByGroupIdAndUserIds(groupId, userIds);
+    }
+
+    @Override
+    public int countByGroupId(Long groupId) {
+        return mapper.countByGroupIdAndRole(groupId, GroupRole.MEMBER);
+    }
+
+    @Override
+    public List<UserGroup> findByGroupIdAndRole(Long groupId, GroupRole role) {
+        return mapper.findByGroupIdAndRole(groupId, role);
+    }
+}
+

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/UserRepositoryImpl.java
@@ -1,0 +1,45 @@
+package com.ssafy.BlueStrongMountain.repository;
+
+import com.ssafy.BlueStrongMountain.domain.User;
+import com.ssafy.BlueStrongMountain.repository.mapper.UserMapper;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@AllArgsConstructor
+public class UserRepositoryImpl implements UserRepository{
+    private final UserMapper mapper;
+
+    @Override
+    public User save(User user) {
+        if (user.getId() == null) {
+            mapper.insert(user);  // id 자동 생성됨
+            return user;
+        }
+        mapper.update(user);
+        return user;
+        //throw new UnsupportedOperationException("User update는 별도 구현 필요");
+    }
+
+    @Override
+    public Optional<User> findByEmail(String email) {
+        return Optional.ofNullable(mapper.findByEmail(email));
+    }
+
+    @Override
+    public Optional<User> findByUsername(String username) {
+        return Optional.ofNullable(mapper.findByUsername(username));
+    }
+
+    @Override
+    public Optional<User> findById(Long id) {
+        return Optional.ofNullable(mapper.findById(id));
+    }
+
+    @Override
+    public void delete(Long id) {
+        mapper.delete(id);
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/UserSolutionRepository.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/UserSolutionRepository.java
@@ -1,0 +1,17 @@
+package com.ssafy.BlueStrongMountain.repository;
+
+import com.ssafy.BlueStrongMountain.domain.UserSolution;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface UserSolutionRepository {
+
+    UserSolution save(UserSolution userSolution);
+
+    List<UserSolution> findByUserId(Long userId);
+
+    List<UserSolution> findByProblemId(Long problemId);
+
+    Optional<UserSolution> findByUserAndProblem(Long userId, Long problemId);
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/UserSolutionRepositoryImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/UserSolutionRepositoryImpl.java
@@ -1,0 +1,37 @@
+package com.ssafy.BlueStrongMountain.repository;
+
+import com.ssafy.BlueStrongMountain.domain.UserSolution;
+import com.ssafy.BlueStrongMountain.repository.mapper.UserSolutionMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class UserSolutionRepositoryImpl implements UserSolutionRepository {
+
+    private final UserSolutionMapper mapper;
+
+    @Override
+    public UserSolution save(UserSolution userSolution) {
+        mapper.save(userSolution);
+        return userSolution;
+    }
+
+    @Override
+    public List<UserSolution> findByUserId(Long userId) {
+        return mapper.findByUserId(userId);
+    }
+
+    @Override
+    public List<UserSolution> findByProblemId(Long problemId) {
+        return mapper.findByProblemId(problemId);
+    }
+
+    @Override
+    public Optional<UserSolution> findByUserAndProblem(Long userId, Long problemId) {
+        return mapper.findByUserAndProblem(userId, problemId);
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/mapper/BoardMapper.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/mapper/BoardMapper.java
@@ -1,0 +1,21 @@
+package com.ssafy.BlueStrongMountain.repository.mapper;
+
+import com.ssafy.BlueStrongMountain.domain.Board;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface BoardMapper {
+
+    void insert(Board board);
+
+    void update(Board board);
+
+    Board findById(@Param("id") Long id);
+
+    List<Board> findByGroupId(@Param("groupId") Long groupId);
+
+    void delete(@Param("id") Long id);
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/mapper/BoardProblemMapper.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/mapper/BoardProblemMapper.java
@@ -1,0 +1,19 @@
+package com.ssafy.BlueStrongMountain.repository.mapper;
+
+import com.ssafy.BlueStrongMountain.domain.BoardProblem;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface BoardProblemMapper {
+
+    void insert(BoardProblem boardProblem);
+
+    void insertAll(@Param("list") List<BoardProblem> list);
+
+    List<BoardProblem> findByBoardId(@Param("boardId") Long boardId);
+
+    void deleteByBoardId(@Param("boardId") Long boardId);
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/mapper/GroupMapper.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/mapper/GroupMapper.java
@@ -1,0 +1,18 @@
+package com.ssafy.BlueStrongMountain.repository.mapper;
+
+import com.ssafy.BlueStrongMountain.domain.Group;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+@Mapper
+public interface GroupMapper {
+    int insert(Group group);
+    Optional<Group> findById(@Param("id") Long id);
+    List<Group> findByIds(@Param("ids") List<Long> ids);
+    List<Group> findByTitleLike(@Param("keyword") String keyword);
+    int update(Group group);
+    int delete(@Param("id") Long id);
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/mapper/ProblemMapper.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/mapper/ProblemMapper.java
@@ -1,0 +1,18 @@
+package com.ssafy.BlueStrongMountain.repository.mapper;
+
+import com.ssafy.BlueStrongMountain.domain.Problem;
+import com.ssafy.BlueStrongMountain.dto.ProblemDto;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ProblemMapper {
+    List<ProblemDto> findAll();
+    List<ProblemDto> findByIdList(@Param("ids") List<Long> ids);
+//    Optional<Problem> findById(Long id);
+//    List<Problem> findByTag(Long tagId);
+//    void save(Problem problem);
+//    void update(Problem problem);
+
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/mapper/UserGroupMapper.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/mapper/UserGroupMapper.java
@@ -1,0 +1,50 @@
+package com.ssafy.BlueStrongMountain.repository.mapper;
+
+import com.ssafy.BlueStrongMountain.domain.GroupRole;
+import com.ssafy.BlueStrongMountain.domain.UserGroup;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+@Mapper
+public interface UserGroupMapper {
+
+    int insert(UserGroup userGroup);
+
+    Optional<UserGroup> findByUserIdAndGroupId(
+            @Param("userId") Long userId,
+            @Param("groupId") Long groupId
+    );
+
+    List<UserGroup> findByUserId(@Param("userId") Long userId);
+
+    List<UserGroup> findByGroupId(@Param("groupId") Long groupId);
+
+    List<UserGroup> findByGroupIdAndRole(
+            @Param("groupId") Long groupId,
+            @Param("role") GroupRole role
+    );
+
+    int updateRole(
+            @Param("userId") Long userId,
+            @Param("groupId") Long groupId,
+            @Param("role") GroupRole role
+    );
+
+    int deleteByUserIdAndGroupId(
+            @Param("userId") Long userId,
+            @Param("groupId") Long groupId
+    );
+
+    int deleteByGroupIdAndUserIds(
+            @Param("groupId") Long groupId,
+            @Param("userIds") List<Long> userIds
+    );
+
+    int countByGroupIdAndRole(
+            @Param("groupId") Long groupId,
+            @Param("role") GroupRole role
+    );
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/mapper/UserMapper.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/mapper/UserMapper.java
@@ -1,0 +1,20 @@
+package com.ssafy.BlueStrongMountain.repository.mapper;
+
+import com.ssafy.BlueStrongMountain.domain.User;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface UserMapper {
+    void insert(User user);
+
+    void update(User user);
+
+    User findById(@Param("id") Long id);
+
+    User findByEmail(@Param("email") String email);
+
+    User findByUsername(@Param("username") String username);
+
+    void delete(@Param("id") Long id);
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/mapper/UserSolutionMapper.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/mapper/UserSolutionMapper.java
@@ -1,0 +1,19 @@
+package com.ssafy.BlueStrongMountain.repository.mapper;
+
+import com.ssafy.BlueStrongMountain.domain.UserSolution;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+import java.util.Optional;
+
+@Mapper
+public interface UserSolutionMapper {
+
+    void save(UserSolution userSolution);
+
+    List<UserSolution> findByUserId(Long userId);
+
+    List<UserSolution> findByProblemId(Long problemId);
+
+    Optional<UserSolution> findByUserAndProblem(Long userId, Long problemId);
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/GroupServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/GroupServiceImpl.java
@@ -155,6 +155,10 @@ public class GroupServiceImpl implements GroupService {
                 now
         );
 
+        //test
+        System.out.println("update user!!!!! test");
+        System.out.println(group.toString());
+
         groupRepository.save(group);
     }
 

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/ProblemFetchServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/ProblemFetchServiceImpl.java
@@ -1,28 +1,31 @@
 package com.ssafy.BlueStrongMountain.service;
 
+import com.ssafy.BlueStrongMountain.domain.Board;
+import com.ssafy.BlueStrongMountain.domain.BoardProblem;
+import com.ssafy.BlueStrongMountain.domain.UserGroup;
+import com.ssafy.BlueStrongMountain.domain.UserSolution;
 import com.ssafy.BlueStrongMountain.dto.ProblemDto;
-import com.ssafy.BlueStrongMountain.repository.GroupRepository;
-import com.ssafy.BlueStrongMountain.repository.ProblemRepository;
+import com.ssafy.BlueStrongMountain.repository.*;
+
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
+
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class ProblemFetchServiceImpl implements ProblemFetchService{
     private final ProblemRepository problemRepository;
-    //private final BoardRepository boardRepository;
-    private final GroupRepository groupRepository;
+    private final BoardRepository boardRepository;
+    private final BoardProblemRepository boardProblemRepository;
+    private final UserGroupRepository userGroupRepository;
+    private final UserSolutionRepository userSolutionRepository;
 
-    public ProblemFetchServiceImpl(
-            //ProblemRepository problemRepository,
-            //BoardRepository boardRepository
-            ProblemRepository problemRepository,
-            GroupRepository groupRepository
-    ) {
-        this.problemRepository = problemRepository;
-        this.groupRepository = groupRepository;
-        //this.boardRepository = boardRepository;
-    }
+
     @Override
     public List<ProblemDto> fetchBaseProblems(Long groupId, Boolean unsolved) {
         if (Boolean.TRUE.equals(unsolved)) {
@@ -31,7 +34,8 @@ public class ProblemFetchServiceImpl implements ProblemFetchService{
             // 모든 문제를 가져옴
             List<ProblemDto> allProblems = problemRepository.findAll();
 
-            List<Long> solvedProblemIds = groupRepository.findUsersSolvedProblems(groupId);
+            //TODO mock 제거
+            List<Long> solvedProblemIds = extractDistinctSolvedProblemIds(groupId);
 
             System.out.println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
             System.out.println("test unsolved problems");
@@ -54,7 +58,36 @@ public class ProblemFetchServiceImpl implements ProblemFetchService{
 
     @Override
     public List<ProblemDto> fetchReviewProblems(Long groupId) {
-        List<Long> problemIds = groupRepository.findGroupSolvedProblems(groupId);
-        return problemRepository.findByIdList(problemIds);
+        List<Board> boards = boardRepository.findByGroupId(groupId);
+
+        Set<Long> problemIds = new HashSet<>();
+
+        for (Board board : boards) {
+            List<BoardProblem> bps = boardProblemRepository.findByBoardId(board.getId());
+            for (BoardProblem bp : bps) {
+                problemIds.add(bp.getProblemId()); // 중복 자동 제거
+            }
+        }
+        return problemRepository.findByIdList(new ArrayList<>(problemIds));
+    }
+//    private List<Long> findUsersSolvedProblems() {
+//        return MOCK_EACH_USERS_SOLVED_PROBLEMS.stream()
+//                .map(UserSolvedDto::getProblemId)
+//                .distinct()
+//                .collect(Collectors.toList());
+//    }
+    private List<Long> extractDistinctSolvedProblemIds(Long groupId){
+        List<UserGroup> userGroups = userGroupRepository.findByGroupId(groupId);
+
+        Set<Long> problemIds = new HashSet<>();
+        for(UserGroup ug : userGroups){
+            Long userId = ug.getUserId();
+            List<UserSolution> solutions = userSolutionRepository.findByUserId(userId);
+
+            for(UserSolution s : solutions){
+                problemIds.add(s.getProblemId());
+            }
+        }
+        return new ArrayList<>(problemIds);
     }
 }

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/UserSolutionService.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/UserSolutionService.java
@@ -1,0 +1,23 @@
+package com.ssafy.BlueStrongMountain.service;
+
+import com.ssafy.BlueStrongMountain.domain.UserSolution;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface UserSolutionService {
+
+    UserSolution save(UserSolution userSolution);
+
+    List<UserSolution> findByUserId(Long userId);
+
+    List<UserSolution> findByProblemId(Long problemId);
+
+    Optional<UserSolution> findByUserAndProblem(Long userId, Long problemId);
+
+    // 불필요 중복 방지용 (선택)
+    boolean hasSolved(Long userId, Long problemId);
+
+    // problemId만 추출하는 편의 메서드 (자주 쓰임)
+    List<Long> findSolvedProblemIds(Long userId);
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/UserSolutionServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/UserSolutionServiceImpl.java
@@ -1,0 +1,56 @@
+package com.ssafy.BlueStrongMountain.service;
+
+import com.ssafy.BlueStrongMountain.domain.UserSolution;
+import com.ssafy.BlueStrongMountain.repository.UserSolutionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class UserSolutionServiceImpl implements UserSolutionService {
+
+    private final UserSolutionRepository userSolutionRepository;
+
+    @Override
+    public UserSolution save(UserSolution userSolution) {
+        return userSolutionRepository.save(userSolution);
+    }
+
+    @Override
+    public List<UserSolution> findByUserId(Long userId) {
+        return userSolutionRepository.findByUserId(userId);
+    }
+
+    @Override
+    public List<UserSolution> findByProblemId(Long problemId) {
+        return userSolutionRepository.findByProblemId(problemId);
+    }
+
+    @Override
+    public Optional<UserSolution> findByUserAndProblem(Long userId, Long problemId) {
+        return userSolutionRepository.findByUserAndProblem(userId, problemId);
+    }
+
+    @Override
+    public boolean hasSolved(Long userId, Long problemId) {
+        return userSolutionRepository.findByUserAndProblem(userId, problemId).isPresent();
+    }
+
+    @Override
+    public List<Long> findSolvedProblemIds(Long userId) {
+        List<UserSolution> solutions = userSolutionRepository.findByUserId(userId);
+
+        List<Long> ids = new ArrayList<>();
+
+        for (UserSolution s : solutions) {
+            ids.add(s.getProblemId());
+        }
+
+        return ids;
+    }
+}
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,20 +2,18 @@ spring.application.name=BlueStrongMountain
 
 server.port=8080
 
-#jsp setting...
-spring.mvc.view.prefix=/WEB-INF/views/
-spring.mvc.view.suffix=.jsp
+spring.devtools.restart.enabled=true
 
 #db setting....
-spring.datasource.url=jdbc:mysql://127.0.0.1:3306/scottdb?serverTimezone=UTC
-spring.datasource.username=root
-spring.datasource.password=root
+spring.datasource.url=jdbc:mysql://127.0.0.1:3306/bst
+#db username, password ??
+spring.datasource.username=
+spring.datasource.password=
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 #mybatis setting( mapper file , type alias): multi package: list vo packages seperated by ,
-#mybatis.type-aliases-package=com.mvc.dto
-
-mybatis.mapper-locations=classpath:/mapper/*Mapper.xml
+mybatis.type-aliases-package=com.ssafy.BlueStrongMountain.domain
+mybatis.mapper-locations=classpath:mybatis/mapper/*Mapper.xml
 
 #log
 logging.level.com.mvc.mapper=debug

--- a/src/main/resources/mybatis/mapper/BoardMapper.xml
+++ b/src/main/resources/mybatis/mapper/BoardMapper.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.ssafy.BlueStrongMountain.repository.mapper.BoardMapper">
+
+    <resultMap id="BoardMap" type="com.ssafy.BlueStrongMountain.domain.Board">
+        <id     property="id"         column="id"/>
+        <result property="groupId"    column="group_id"/>
+        <result property="writerId"   column="writer_id"/>
+        <result property="title"      column="title"/>
+        <result property="content"    column="content"/>
+        <result property="startTime"  column="start_time"/>
+        <result property="endTime"    column="end_time"/>
+        <result property="viewCount"  column="view_count"/>
+        <result property="createdAt"  column="created_at"/>
+        <result property="updatedAt"  column="updated_at"/>
+    </resultMap>
+
+    <!-- INSERT -->
+    <insert id="insert" parameterType="com.ssafy.BlueStrongMountain.domain.Board" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO boards
+        (group_id, writer_id, title, content, start_time, end_time, view_count, created_at, updated_at)
+        VALUES
+            (#{groupId}, #{writerId}, #{title}, #{content}, #{startTime}, #{endTime},
+             #{viewCount}, #{createdAt}, #{updatedAt});
+    </insert>
+
+    <!-- UPDATE -->
+    <update id="update" parameterType="com.ssafy.BlueStrongMountain.domain.Board">
+        UPDATE boards
+        SET
+            title = #{title},
+            content = #{content},
+            end_time = #{endTime},
+            updated_at = #{updatedAt}
+        WHERE id = #{id}
+    </update>
+
+
+    <!-- findById -->
+    <select id="findById" resultMap="BoardMap">
+        SELECT *
+        FROM boards
+        WHERE id = #{id}
+    </select>
+
+    <!-- findByGroupId -->
+    <select id="findByGroupId" resultMap="BoardMap">
+        SELECT *
+        FROM boards
+        WHERE group_id = #{groupId}
+        ORDER BY id ASC
+    </select>
+
+    <!-- delete -->
+    <delete id="delete">
+        DELETE FROM boards WHERE id = #{id}
+    </delete>
+
+</mapper>

--- a/src/main/resources/mybatis/mapper/BoardProblemMapper.xml
+++ b/src/main/resources/mybatis/mapper/BoardProblemMapper.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.ssafy.BlueStrongMountain.repository.mapper.BoardProblemMapper">
+
+    <resultMap id="BoardProblemMap" type="com.ssafy.BlueStrongMountain.domain.BoardProblem">
+        <id     property="id"         column="id"/>
+        <result property="boardId"    column="board_id"/>
+        <result property="problemId"  column="problem_id"/>
+        <result property="orderIndex" column="order_index"/>
+        <result property="createdAt"  column="created_at"/>
+        <result property="updatedAt"  column="updated_at"/>
+    </resultMap>
+
+    <!-- 단건 INSERT -->
+    <insert id="insert" parameterType="com.ssafy.BlueStrongMountain.domain.BoardProblem"
+            useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO board_problems
+            (board_id, problem_id, order_index, created_at, updated_at)
+        VALUES
+            (#{boardId}, #{problemId}, #{orderIndex}, #{createdAt}, #{updatedAt});
+    </insert>
+
+    <!-- bulk insert -->
+    <insert id="insertAll">
+        INSERT INTO board_problems
+        (board_id, problem_id, order_index, created_at, updated_at)
+        VALUES
+        <foreach collection="list" item="p" separator=",">
+            (#{p.boardId}, #{p.problemId}, #{p.orderIndex}, #{p.createdAt}, #{p.updatedAt})
+        </foreach>
+    </insert>
+
+    <!-- findByBoardId -->
+    <select id="findByBoardId" resultMap="BoardProblemMap">
+        SELECT *
+        FROM board_problems
+        WHERE board_id = #{boardId}
+        ORDER BY order_index ASC
+    </select>
+
+    <!-- deleteByBoardId -->
+    <delete id="deleteByBoardId">
+        DELETE FROM board_problems
+        WHERE board_id = #{boardId}
+    </delete>
+
+</mapper>

--- a/src/main/resources/mybatis/mapper/GroupMapper.xml
+++ b/src/main/resources/mybatis/mapper/GroupMapper.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.ssafy.BlueStrongMountain.repository.mapper.GroupMapper">
+
+    <!-- ResultMap -->
+    <resultMap id="GroupMap" type="com.ssafy.BlueStrongMountain.domain.Group">
+        <id property="id" column="id"/>
+        <result property="title" column="name"/>
+        <result property="description" column="description"/>
+        <result property="visibility" column="visibility"/>
+        <result property="ownerId" column="owner_id"/>
+        <result property="createdAt" column="created_at"/>
+        <result property="updatedAt" column="updated_at"/>
+    </resultMap>
+
+    <!-- INSERT -->
+    <insert id="insert" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO groupz
+            (name, description, visibility, owner_id, created_at, updated_at)
+        VALUES
+            (#{title}, #{description}, #{visibility}, #{ownerId}, #{createdAt}, #{updatedAt})
+    </insert>
+
+    <!-- findById -->
+    <select id="findById" resultMap="GroupMap">
+        SELECT *
+        FROM groupz
+        WHERE id = #{id}
+    </select>
+
+    <!-- findByIds -->
+    <select id="findByIds" resultMap="GroupMap">
+        SELECT *
+        FROM groupz
+        WHERE id IN
+        <foreach collection="ids" item="id" open="(" separator="," close=")">
+            #{id}
+        </foreach>
+    </select>
+
+    <!-- findByTitleLike -->
+    <select id="findByTitleLike" resultMap="GroupMap">
+        SELECT *
+        FROM groupz
+        WHERE LOWER(name) LIKE CONCAT('%', LOWER(#{keyword}), '%')
+    </select>
+
+    <!-- UPDATE -->
+    <update id="update">
+        UPDATE groupz
+        SET
+            name = #{title},
+            description = #{description},
+            visibility = #{visibility},
+            updated_at = #{updatedAt}
+        WHERE id = #{id}
+    </update>
+
+    <!-- DELETE -->
+    <delete id="delete">
+        DELETE FROM groupz
+        WHERE id = #{id}
+    </delete>
+
+</mapper>

--- a/src/main/resources/mybatis/mapper/ProblemMapper.xml
+++ b/src/main/resources/mybatis/mapper/ProblemMapper.xml
@@ -13,7 +13,12 @@
         <result property="updatedAt" column="last_synced_at"/>
 
         <!-- tags (List<String>) -->
-        <collection property="tags" ofType="string" column="tag_name"/>
+<!--        <collection property="tags" ofType="string" column="tag_name"/>-->
+        <collection property="tags"
+                    javaType="java.util.ArrayList"
+                    ofType="java.lang.String">
+            <result column="tag_name"/>
+        </collection>
     </resultMap>
 
     <select id="findAll" resultMap="ProblemDtoMap">

--- a/src/main/resources/mybatis/mapper/ProblemMapper.xml
+++ b/src/main/resources/mybatis/mapper/ProblemMapper.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.ssafy.BlueStrongMountain.repository.mapper.ProblemMapper">
+
+    <resultMap id="ProblemDtoMap" type="com.ssafy.BlueStrongMountain.dto.ProblemDto">
+        <id property="id" column="id"/>
+        <result property="title" column="title"/>
+        <result property="difficulty" column="difficulty"/>
+        <result property="acceptedUserCount" column="accepted_user_count"/>
+        <result property="updatedAt" column="last_synced_at"/>
+
+        <!-- tags (List<String>) -->
+        <collection property="tags" ofType="string" column="tag_name"/>
+    </resultMap>
+
+    <select id="findAll" resultMap="ProblemDtoMap">
+        SELECT
+            p.id,
+            p.title,
+            p.difficulty,
+            p.accepted_user_count,
+            p.last_synced_at,
+            t.name AS tag_name
+        FROM problems p
+                 LEFT JOIN problem_tags pt ON p.id = pt.problem_id
+                 LEFT JOIN tags t ON pt.tag_id = t.id
+        ORDER BY p.id
+    </select>
+
+    <select id="findByIdList" resultMap="ProblemDtoMap">
+        SELECT
+        p.id,
+        p.title,
+        p.difficulty,
+        p.accepted_user_count,
+        p.last_synced_at,
+        t.name AS tag_name
+        FROM problems p
+        LEFT JOIN problem_tags pt ON p.id = pt.problem_id
+        LEFT JOIN tags t ON pt.tag_id = t.id
+        WHERE p.id IN
+        <foreach item="id" collection="ids" open="(" separator="," close=")">
+            #{id}
+        </foreach>
+        ORDER BY p.id
+    </select>
+
+
+</mapper>

--- a/src/main/resources/mybatis/mapper/UserGroupMapper.xml
+++ b/src/main/resources/mybatis/mapper/UserGroupMapper.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.ssafy.BlueStrongMountain.repository.mapper.UserGroupMapper">
+
+    <!-- ResultMap: id/status는 도메인에 없으므로 제외 -->
+    <resultMap id="UserGroupMap" type="com.ssafy.BlueStrongMountain.domain.UserGroup">
+        <result property="userId" column="user_id"/>
+        <result property="groupId" column="group_id"/>
+        <result property="role" column="role"/>
+        <result property="joinedAt" column="joined_at"/>
+    </resultMap>
+
+    <!-- INSERT -->
+    <!-- id/status는 자동 처리되므로 입력 안함 -->
+    <insert id="insert">
+        INSERT INTO user_groups
+            (user_id, group_id, role, joined_at)
+        VALUES
+            (#{userId}, #{groupId}, #{role}, #{joinedAt})
+    </insert>
+
+    <!-- SELECT: findByUserId -->
+    <select id="findByUserId" resultMap="UserGroupMap">
+        SELECT user_id, group_id, role, joined_at
+        FROM user_groups
+        WHERE user_id = #{userId}
+    </select>
+
+    <!-- SELECT: findByGroupId -->
+    <select id="findByGroupId" resultMap="UserGroupMap">
+        SELECT user_id, group_id, role, joined_at
+        FROM user_groups
+        WHERE group_id = #{groupId}
+    </select>
+
+    <!-- SELECT: findByUserIdAndGroupId -->
+    <select id="findByUserIdAndGroupId" resultMap="UserGroupMap">
+        SELECT user_id, group_id, role, joined_at
+        FROM user_groups
+        WHERE user_id = #{userId}
+          AND group_id = #{groupId}
+    </select>
+
+    <!-- SELECT: findByGroupIdAndRole -->
+    <select id="findByGroupIdAndRole" resultMap="UserGroupMap">
+        SELECT user_id, group_id, role, joined_at
+        FROM user_groups
+        WHERE group_id = #{groupId}
+          AND role = #{role}
+    </select>
+
+    <!-- UPDATE role 변경 -->
+    <update id="updateRole">
+        UPDATE user_groups
+        SET role = #{role}
+        WHERE user_id = #{userId}
+          AND group_id = #{groupId}
+    </update>
+
+    <!-- DELETE -->
+    <delete id="deleteByUserIdAndGroupId">
+        DELETE FROM user_groups
+        WHERE user_id = #{userId}
+          AND group_id = #{groupId}
+    </delete>
+
+    <!-- BULK DELETE -->
+    <delete id="deleteByGroupIdAndUserIds">
+        DELETE FROM user_groups
+        WHERE group_id = #{groupId}
+        AND user_id IN
+        <foreach collection="userIds" item="uid" open="(" separator="," close=")">
+            #{uid}
+        </foreach>
+    </delete>
+
+    <!-- COUNT -->
+    <select id="countByGroupIdAndRole" resultType="int">
+        SELECT COUNT(*)
+        FROM user_groups
+        WHERE group_id = #{groupId}
+          AND role = #{role}
+    </select>
+
+</mapper>

--- a/src/main/resources/mybatis/mapper/UserMapper.xml
+++ b/src/main/resources/mybatis/mapper/UserMapper.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.ssafy.BlueStrongMountain.repository.mapper.UserMapper">
+
+    <resultMap id="UserResultMap" type="com.ssafy.BlueStrongMountain.domain.User">
+        <id property="id" column="id" />
+        <result property="email" column="email" />
+        <result property="password" column="password" />
+        <result property="username" column="username" />
+        <result property="baekjoonHandle" column="baekjoon" />
+        <result property="status" column="status" />
+        <result property="role" column="role" />
+        <result property="refreshToken" column="refresh_token" />
+        <result property="createdAt" column="created_at" />
+        <result property="updatedAt" column="updated_at" />
+    </resultMap>
+
+    <insert id="insert" parameterType="com.ssafy.BlueStrongMountain.domain.User" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO users (email, password, username, baekjoon, status, role, refresh_token, created_at, updated_at)
+        VALUES (#{email}, #{password}, #{username}, #{baekjoonHandle}, #{status}, #{role}, #{refreshToken}, #{createdAt}, #{updatedAt})
+    </insert>
+
+    <update id="update" parameterType="com.ssafy.BlueStrongMountain.domain.User">
+        UPDATE users
+        SET
+            email = #{email},
+            password = #{password},
+            username = #{username},
+            baekjoon = #{baekjoonHandle},
+            status = #{status},
+            role = #{role},
+            refresh_token = #{refreshToken},
+            updated_at = #{updatedAt}
+        WHERE id = #{id}
+    </update>
+
+
+    <select id="findById" resultMap="UserResultMap">
+        SELECT * FROM users WHERE id = #{id}
+    </select>
+
+    <select id="findByEmail" resultMap="UserResultMap">
+        SELECT * FROM users WHERE email = #{email}
+    </select>
+
+    <select id="findByUsername" resultMap="UserResultMap">
+        SELECT * FROM users WHERE username = #{username}
+    </select>
+
+    <delete id="delete">
+        DELETE FROM users WHERE id = #{id}
+    </delete>
+
+</mapper>

--- a/src/main/resources/mybatis/mapper/UserSolutionMapper.xml
+++ b/src/main/resources/mybatis/mapper/UserSolutionMapper.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.ssafy.BlueStrongMountain.repository.mapper.UserSolutionMapper">
+
+    <resultMap id="UserSolutionMap" type="com.ssafy.BlueStrongMountain.domain.UserSolution">
+        <id property="id" column="id"/>
+        <result property="userId" column="user_id"/>
+        <result property="problemId" column="problem_id"/>
+        <result property="solvedAt" column="solved_at"/>
+        <result property="createdAt" column="created_at"/>
+    </resultMap>
+
+    <!-- INSERT (유저가 문제를 처음 풀었을 때 저장) -->
+    <insert id="save" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO user_solutions (user_id, problem_id, solved_at, created_at)
+        VALUES (#{userId}, #{problemId}, #{solvedAt}, #{createdAt})
+    </insert>
+
+    <!-- 특정 유저의 solved 문제 목록 -->
+    <select id="findByUserId" resultMap="UserSolutionMap">
+        SELECT *
+        FROM user_solutions
+        WHERE user_id = #{userId}
+    </select>
+
+    <!-- 특정 문제를 푼 유저 목록 -->
+    <select id="findByProblemId" resultMap="UserSolutionMap">
+        SELECT *
+        FROM user_solutions
+        WHERE problem_id = #{problemId}
+    </select>
+
+    <!-- 단일 조회 -->
+    <select id="findByUserAndProblem" resultMap="UserSolutionMap">
+        SELECT *
+        FROM user_solutions
+        WHERE user_id = #{userId}
+          AND problem_id = #{problemId}
+    </select>
+
+</mapper>


### PR DESCRIPTION
이슈번호: https://github.com/cheonggangsan/BlueStrongMountain_backend/issues/21

---

## 1. 작업 개요

본 PR에서는 프로젝트 전반에서 사용되는 주요 도메인
**User, Problem, Board, Group, UserSolution**
에 대해 다음 사항을 공통 구조로 정비했습니다.

1. 각 도메인별 MyBatis Mapper 구현
2. Mapper 인터페이스 및 Repository 계층 정리
3. Board-Group-Problem 연계 로직을 통한 중복 제거 문제 ID 추출 기능 구현
4. UserSolution 기반 solved problem 조회 구조 구축
5. 백준 인증 기능명 REST 규칙에 맞게 재정의

기능 전체가 일관된 계층 구조로 정리되어, 이후 서비스 확장 시 유지보수성을 높였습니다.

---

## 2. 도메인별 매퍼 및 레포지토리 구현 요약

### 2.1 User

* User Entity에 맞게 resultMap 구성
* email, id 기반 조회 기능 Mapper 구현
* Repository를 통해 도메인 조회와 저장 책임을 분리

### 2.2 Problem

* Problem 정보 조회를 위한 resultMap 구성
* 다중 problemId 리스트 조회 기능 구현
* 태그 조인과 같은 확장 기능을 고려한 구조로 설정

### 2.3 Group

* 그룹 기본 정보 조회 Mapper 작성
* groupId 기반 조회 기능 제공
* Group 도메인을 중심으로 board·problem 로직이 확장될 수 있도록 구조 설계

### 2.4 Board

* groupId 기준으로 해당 그룹에 속한 board 목록 조회 Mapper 구현
* Board 도메인의 기본 조회 기능만 분리하여, 서비스 계층에서 조합 사용 가능하도록 구성

### 2.5 UserSolution

* user_solutions 테이블 기반 도메인 정의
* userId 기준 solved 문제 목록 조회 Mapper 구현
* Repository 계층에서 서비스에 필요한 형태로 가공할 수 있도록 구조 제공

---

## 3. 서비스 로직 개선 사항

### 3.1 Group → Board → BoardProblem 기반 Problem ID 추출

* groupId로 소속된 board 목록을 조회
* 각 board에 연결된 문제 목록(board_problems)을 조회
* 중복 문제 ID를 제거하여 그룹 전체의 문제 ID 집합 생성
* 서비스 계층에서 사용될 수 있는 단일한 문제 ID 리스트 제공

이 로직을 통해 그룹 전체가 학습한 문제를 정확하게 집계할 수 있게 됨.

### 3.2 UserSolution → problemId 리스트 변환 기능

* userId 기준으로 UserSolution 목록 조회
* 해결한 문제들의 problemId만 추출
* 중복 제거 후 리스트 형태로 반환

이 작업은
"유저가 어떤 문제를 풀었는가?"
라는 핵심 요구사항을 서비스 계층에서 쉽게 사용할 수 있도록 메서드 단위로 정리됨.




