### PR TITLE
[BST-25] 그룹 상세 조회 API 구현 

### DIFF
--- a/src/main/java/com/ssafy/BlueStrongMountain/controller/GroupController.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/controller/GroupController.java
@@ -37,7 +37,7 @@ public class GroupController {
     /**
      * 그룹 상세조회
      */
-    @GetMapping("/detail/{groupId}")
+    @GetMapping("/{groupId}/detail")
     public ResponseEntity<GroupDetailDto> getGroupDetail(
             @RequestParam Long requesterId,
             @PathVariable Long groupId

--- a/src/main/java/com/ssafy/BlueStrongMountain/controller/GroupController.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/controller/GroupController.java
@@ -1,9 +1,6 @@
 package com.ssafy.BlueStrongMountain.controller;
 
-import com.ssafy.BlueStrongMountain.dto.BaseResponse;
-import com.ssafy.BlueStrongMountain.dto.GroupCreateRequest;
-import com.ssafy.BlueStrongMountain.dto.GroupSummaryDto;
-import com.ssafy.BlueStrongMountain.dto.GroupUpdateRequest;
+import com.ssafy.BlueStrongMountain.dto.*;
 import com.ssafy.BlueStrongMountain.service.GroupMemberService;
 import com.ssafy.BlueStrongMountain.service.GroupService;
 
@@ -35,6 +32,17 @@ public class GroupController {
         System.out.println(createdGroupId);
 
         return ResponseEntity.ok(BaseResponse.ok());
+    }
+
+    /**
+     * 그룹 상세조회
+     */
+    @GetMapping("/detail/{groupId}")
+    public ResponseEntity<GroupDetailDto> getGroupDetail(
+            @RequestParam Long requesterId,
+            @PathVariable Long groupId
+    ){
+        return ResponseEntity.ok(groupService.getGroupDetail(requesterId, groupId));
     }
 
     /**

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/GroupDetailDto.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/GroupDetailDto.java
@@ -1,9 +1,7 @@
 package com.ssafy.BlueStrongMountain.dto;
 
-import jakarta.annotation.security.DenyAll;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 import java.util.List;

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/GroupDetailDto.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/GroupDetailDto.java
@@ -1,0 +1,24 @@
+package com.ssafy.BlueStrongMountain.dto;
+
+import jakarta.annotation.security.DenyAll;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@ToString
+public class GroupDetailDto {
+    private final Long id;
+    private final String title;
+    private final String description;
+    private final Long ownerId;
+    private final List<Long> managers;
+    private final List<Long> members;
+    private final String visibility;
+    private final String createdAt;
+    private final String updatedAt;
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/GroupService.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/GroupService.java
@@ -1,12 +1,14 @@
 package com.ssafy.BlueStrongMountain.service;
 
 import com.ssafy.BlueStrongMountain.dto.GroupCreateRequest;
+import com.ssafy.BlueStrongMountain.dto.GroupDetailDto;
 import com.ssafy.BlueStrongMountain.dto.GroupSummaryDto;
 import com.ssafy.BlueStrongMountain.dto.GroupUpdateRequest;
 import java.util.List;
 
 public interface GroupService {
     Long createGroup(Long ownerId, GroupCreateRequest request);
+    GroupDetailDto getGroupDetail(Long requesterId, Long groupId);
     List<GroupSummaryDto> findMyGroups(Long requesterId);
     List<GroupSummaryDto> searchMyGroups(Long requesterId, String name);
     void updateGroup(Long requesterId, Long groupId, GroupUpdateRequest request);

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/GroupServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/GroupServiceImpl.java
@@ -1,10 +1,8 @@
 package com.ssafy.BlueStrongMountain.service;
 
-import com.ssafy.BlueStrongMountain.domain.Group;
-import com.ssafy.BlueStrongMountain.domain.GroupRole;
-import com.ssafy.BlueStrongMountain.domain.GroupVisibility;
-import com.ssafy.BlueStrongMountain.domain.UserGroup;
+import com.ssafy.BlueStrongMountain.domain.*;
 import com.ssafy.BlueStrongMountain.dto.GroupCreateRequest;
+import com.ssafy.BlueStrongMountain.dto.GroupDetailDto;
 import com.ssafy.BlueStrongMountain.dto.GroupSummaryDto;
 import com.ssafy.BlueStrongMountain.dto.GroupUpdateRequest;
 import com.ssafy.BlueStrongMountain.exception.GroupNotFoundException;
@@ -79,6 +77,36 @@ public class GroupServiceImpl implements GroupService {
         }
 
         return saved.getId();
+    }
+
+    @Override
+    public GroupDetailDto getGroupDetail(final Long requesterId, final Long groupId){
+        groupAuthorityService.validateUserInGroup(requesterId, groupId);
+
+        Group findGroup = groupRepository.findById(groupId)
+                .orElseThrow(() -> new GroupNotFoundException(groupId));
+
+        List<Long> memberIds = userGroupRepository.findByGroupIdAndRole(groupId, GroupRole.MEMBER)
+                .stream()
+                .map(UserGroup::getUserId)
+                .toList();
+
+        List<Long> managerIds = userGroupRepository.findByGroupIdAndRole(groupId, GroupRole.MANAGER)
+                .stream()
+                .map(UserGroup::getUserId)
+                .toList();
+
+        return new GroupDetailDto(
+                findGroup.getId(),
+                findGroup.getTitle(),
+                findGroup.getDescription(),
+                findGroup.getOwnerId(),
+                managerIds,
+                memberIds,
+                findGroup.getVisibility().name(),
+                findGroup.getCreatedAt().toString(),
+                findGroup.getUpdatedAt().toString()
+        );
     }
 
     @Override


### PR DESCRIPTION
이슈번호: https://github.com/cheonggangsan/BlueStrongMountain_backend/issues/25
---

# 1. 구현 내용

### 1) 그룹 상세 조회 API 구현

- `GET /api/v1/groups/detail/{groupId}` 엔드포인트 추가
- 요청자(`requesterId`)의 그룹 접근 권한 검증 추가
- 그룹의 기본 정보(title, description, ownerId 등) 반환
- 그룹 내 **MANAGER** / **MEMBER** 역할 사용자 ID 리스트 반환
- visibility, createdAt, updatedAt 등 메타 정보 포함
- 응답은 immutable 구조의 `GroupDetailDto`로 반환

### 2) Service 로직 구현

- `GroupService`에 `getGroupDetail(requesterId, groupId)` 메서드 구현
- 요청자 권한 검증: `groupAuthorityService.validateUserInGroup()` 사용
- 그룹 엔티티 조회: `groupRepository.findById()`
- 멤버/매니저 조회:
    - `userGroupRepository.findByGroupIdAndRole(groupId, MEMBER)`
    - `userGroupRepository.findByGroupIdAndRole(groupId, MANAGER)`
- 필요한 사용자 ID만 추출하여 DTO로 전달
- 그룹이 존재하지 않을 경우 `GroupNotFoundException(groupId)` 발생
- DTO는 생성자를 통한 불변 데이터 구조 유지

### 3) Controller 엔드포인트 구현

- `GroupController` 내 `getGroupDetail()` 추가
- `@GetMapping("/detail/{groupId}")` 사용
- `@RequestParam requesterId` + `@PathVariable groupId` 구조
- `ResponseEntity<GroupDetailDto>` 형태로 반환

### 4) Swagger 스펙 정의

- `/detail/{groupId}` API에 대해 summary/description/parameters/responses 작성
- `GroupDetailDto` 스키마 정의(역할별 사용자 리스트 포함)

---

# 2. 변경된 모듈

## 변경

### controller

- `GroupController`에 그룹 상세 조회 API 추가

### service

- `GroupService` / `GroupServiceImpl`
    - 상세 조회 로직(`getGroupDetail`) 구현

### dto

- `GroupDetailDto` 생성
    - 불변(final 필드) 구조
    - 그룹 정보와 역할별 사용자 ID 리스트 포함

## 활용

### repository

- `GroupRepository`
- `UserGroupRepository`
    - 그룹 내 특정 역할(MEMBER/MANAGER) 사용자 조회 메서드 활용

### exception

- `GroupNotFoundException`에 groupId 기반 생성자 활용

---

# 3. 동작 흐름 설명

1. **클라이언트 요청**
    - `GET /api/v1/groups/detail/{groupId}?requesterId={id}`
2. **Controller → Service 호출**
    - 파라미터로 requesterId, groupId 전달
3. **권한 검증**
    - 사용자가 해당 그룹의 MEMBER/MANAGER/OWNER인지 확인
    - 아닐 경우 권한 예외 발생
4. **Group 조회**
    - 존재하지 않을 경우 `GroupNotFoundException` 발생
5. **Group 멤버/매니저 조회**
    - user_group 테이블에서 역할별 사용자 추출
    - ID만 리스트 형태로 변환
6. **DTO 생성 및 반환**
    - 불변 DTO로 모든 그룹 정보 + 사용자 리스트 전달
    - Controller는 `ResponseEntity.ok()`로 응답

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 그룹 상세 정보 조회 API 추가 - 그룹 ID를 통해 제목, 설명, 소유자, 관리자, 멤버, 공개 범위 및 생성/수정 날짜를 포함한 상세 정보 조회 가능

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->