### PR TITLE
[BST-29] Owner 변경 및 Group 멤버/권한 관리 API RequestBody DTO 분리 및 UserGroup 저장 로직 개선

### DIFF
--- a/src/main/java/com/ssafy/BlueStrongMountain/controller/GroupController.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/controller/GroupController.java
@@ -107,9 +107,9 @@ public class GroupController {
     public ResponseEntity<BaseResponse> addManager(
             @RequestParam Long requesterId,
             @PathVariable Long groupId,
-            @RequestBody List<Long> newManagerIds
+            @RequestBody GroupAddIdsRequest req
     ) {
-        groupMemberService.addManagers(requesterId, groupId, newManagerIds);
+        groupMemberService.addManagers(requesterId, groupId, req.getUserIds());
         return ResponseEntity.ok(BaseResponse.ok());
     }
 
@@ -133,9 +133,9 @@ public class GroupController {
     public ResponseEntity<BaseResponse> addMember(
             @RequestParam Long requesterId,
             @PathVariable Long groupId,
-            @RequestBody List<Long> newMemberIds
+            @RequestBody GroupAddIdsRequest req
     ) {
-        groupMemberService.addMembers(requesterId, groupId, newMemberIds);
+        groupMemberService.addMembers(requesterId, groupId, req.getUserIds());
         return ResponseEntity.ok(BaseResponse.ok());
     }
 

--- a/src/main/java/com/ssafy/BlueStrongMountain/controller/GroupController.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/controller/GroupController.java
@@ -93,8 +93,9 @@ public class GroupController {
     public ResponseEntity<BaseResponse> changeOwner(
             @RequestParam Long requesterId,
             @PathVariable Long groupId,
-            @RequestBody(required = true) Long newOwnerId
+            @RequestBody GroupChangeOwnerRequest req
     ) {
+        Long newOwnerId = req.getNewOwnerId();
         groupService.changeOwner(requesterId, groupId, newOwnerId);
         return ResponseEntity.ok(BaseResponse.ok());
     }

--- a/src/main/java/com/ssafy/BlueStrongMountain/domain/Group.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/domain/Group.java
@@ -2,8 +2,10 @@ package com.ssafy.BlueStrongMountain.domain;
 
 import java.time.LocalDateTime;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString
 public class Group {
 
     private Long id;

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/GroupAddIdsRequest.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/GroupAddIdsRequest.java
@@ -1,0 +1,12 @@
+package com.ssafy.BlueStrongMountain.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor
+@Getter
+public class GroupAddIdsRequest {
+    private List<Long> userIds;
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/GroupChangeOwnerRequest.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/GroupChangeOwnerRequest.java
@@ -1,0 +1,10 @@
+package com.ssafy.BlueStrongMountain.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class GroupChangeOwnerRequest {
+    private Long newOwnerId;
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/UserGroupRepository.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/UserGroupRepository.java
@@ -7,7 +7,9 @@ import java.util.List;
 import java.util.Optional;
 
 public interface UserGroupRepository {
-    UserGroup save(UserGroup userGroup);
+    //UserGroup save(UserGroup userGroup);
+    void insert(UserGroup userGroup);
+    void updateRole(UserGroup userGroup);
     List<UserGroup> findByUserId(Long userId);
     List<UserGroup> findByGroupId(Long groupId);
     Optional<UserGroup> findByUserIdAndGroupId(Long userId, Long groupId);

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/UserGroupRepositoryImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/UserGroupRepositoryImpl.java
@@ -15,10 +15,20 @@ public class UserGroupRepositoryImpl implements UserGroupRepository {
 
     private final UserGroupMapper mapper;
 
+//    @Override
+//    public UserGroup save(UserGroup userGroup) {
+//        mapper.insert(userGroup);
+//        return userGroup;
+//    }
+
     @Override
-    public UserGroup save(UserGroup userGroup) {
+    public void insert(UserGroup userGroup) {
         mapper.insert(userGroup);
-        return userGroup;
+    }
+
+    @Override
+    public void updateRole(UserGroup userGroup) {
+        mapper.updateRole(userGroup.getUserId(), userGroup.getGroupId(), userGroup.getRole());
     }
 
     @Override
@@ -48,7 +58,9 @@ public class UserGroupRepositoryImpl implements UserGroupRepository {
 
     @Override
     public int countByGroupId(Long groupId) {
-        return mapper.countByGroupIdAndRole(groupId, GroupRole.MEMBER);
+        return mapper.countByGroupIdAndRole(groupId, GroupRole.MEMBER)
+                + mapper.countByGroupIdAndRole(groupId, GroupRole.MANAGER)
+                    + mapper.countByGroupIdAndRole(groupId, GroupRole.OWNER);
     }
 
     @Override

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/GroupMemberServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/GroupMemberServiceImpl.java
@@ -45,7 +45,8 @@ public class GroupMemberServiceImpl implements GroupMemberService {
             }
 
             target.changeRole(GroupRole.MANAGER);
-            userGroupRepository.save(target);
+//            userGroupRepository.save(target);
+            userGroupRepository.updateRole(target);
         }
     }
 
@@ -69,8 +70,9 @@ public class GroupMemberServiceImpl implements GroupMemberService {
                 throw new CannotRemoveOwnerException(managerId, groupId);
             }
 
-            userGroup.changeRole(GroupRole.MEMBER);
-            userGroupRepository.save(userGroup);
+//            userGroup.changeRole(GroupRole.MEMBER);
+//            userGroupRepository.save(userGroup);
+            userGroupRepository.deleteByUserIdAndGroupId(managerId, groupId);
         }
     }
 
@@ -91,7 +93,8 @@ public class GroupMemberServiceImpl implements GroupMemberService {
 
             final LocalDateTime now = LocalDateTime.now();
             final UserGroup userGroup = UserGroup.create(userId, groupId, GroupRole.MEMBER, now);
-            userGroupRepository.save(userGroup);
+            //userGroupRepository.save(userGroup);
+            userGroupRepository.insert(userGroup);
         }
     }
 

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/GroupServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/GroupServiceImpl.java
@@ -60,19 +60,22 @@ public class GroupServiceImpl implements GroupService {
         final Group saved = groupRepository.save(group);
 
         final UserGroup ownerUserGroup = UserGroup.create(ownerId, saved.getId(), GroupRole.OWNER, now);
-        userGroupRepository.save(ownerUserGroup);
+        //userGroupRepository.save(ownerUserGroup);
+        userGroupRepository.insert(ownerUserGroup);
 
         if (request.getManagerIds() != null) {
             for (Long managerId : request.getManagerIds()) {
                 final UserGroup userGroup = UserGroup.create(managerId, saved.getId(), GroupRole.MANAGER, now);
-                userGroupRepository.save(userGroup);
+                //userGroupRepository.save(userGroup);
+                userGroupRepository.insert(userGroup);
             }
         }
 
         if (request.getMemberIds() != null) {
             for (Long memberId : request.getMemberIds()) {
                 final UserGroup userGroup = UserGroup.create(memberId, saved.getId(), GroupRole.MEMBER, now);
-                userGroupRepository.save(userGroup);
+                //userGroupRepository.save(userGroup);
+                userGroupRepository.insert(userGroup);
             }
         }
 
@@ -183,9 +186,9 @@ public class GroupServiceImpl implements GroupService {
                 now
         );
 
-        //test
-        System.out.println("update user!!!!! test");
-        System.out.println(group.toString());
+//        //test
+//        System.out.println("update user!!!!! test");
+//        System.out.println(group.toString());
 
         groupRepository.save(group);
     }
@@ -198,11 +201,18 @@ public class GroupServiceImpl implements GroupService {
     ) {
         groupAuthorityService.validateOwnerTransferable(requesterId, groupId, newOwnerId);
 
-        final Group group = groupRepository.findById(groupId)
+        final Group findGroup = groupRepository.findById(groupId)
                 .orElseThrow(() -> new GroupNotFoundException(groupId));
 
         final LocalDateTime now = LocalDateTime.now();
-        group.changeOwner(newOwnerId, now);
+        findGroup.changeOwner(newOwnerId, now);
+        groupRepository.save(findGroup);
+
+//        //test
+//        System.out.println("group update test!!!!!!!!!!!!!!!!");
+//        System.out.println(findGroup.toString());
+//        System.out.println("group update test_end!!!!!!!!!!!!!!!!");
+//        //test
 
 //        //test
 //        System.out.println("before group size" + userGroupRepository.findByUserId(requesterId).size());
@@ -213,11 +223,16 @@ public class GroupServiceImpl implements GroupService {
         final UserGroup oldOwner = userGroupRepository.findByUserIdAndGroupId(requesterId, groupId)
                 .orElseThrow(() -> new GroupNotFoundException(groupId));
         oldOwner.changeRole(GroupRole.MEMBER);
-        userGroupRepository.save(oldOwner);
+
+        userGroupRepository.updateRole(oldOwner);
 
         final UserGroup newOwner = userGroupRepository.findByUserIdAndGroupId(newOwnerId, groupId)
                 .orElseThrow(() -> new GroupNotFoundException(groupId));
         newOwner.changeRole(GroupRole.OWNER);
-        userGroupRepository.save(newOwner);
+
+        userGroupRepository.updateRole(newOwner);
+//
+//        userGroupRepository.save(oldOwner);
+//        userGroupRepository.save(newOwner);
     }
 }

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/GroupServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/GroupServiceImpl.java
@@ -44,7 +44,7 @@ public class GroupServiceImpl implements GroupService {
             final Long ownerId,
             final GroupCreateRequest request
     ) {
-        groupValidator.validateCreateRequest(request);
+        groupValidator.validateCreateRequest(ownerId, request);
 
         final LocalDateTime now = LocalDateTime.now();
         final GroupVisibility visibility = GroupVisibility.PRIVATE;

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/validator/GroupValidator.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/validator/GroupValidator.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class GroupValidator {
 
-    public void validateCreateRequest(final GroupCreateRequest request) {
+    public void validateCreateRequest(final Long ownerId, final GroupCreateRequest request) {
         if (request == null) {
             throw new InvalidGroupCreateException("Request must not be null.");
         }
@@ -22,7 +22,7 @@ public class GroupValidator {
             throw new InvalidGroupCreateException("Group title must not be empty.");
         }
 
-        validateDuplicateIds(request.getManagerIds(), request.getMemberIds());
+        validateDuplicateIds(ownerId, request.getManagerIds(), request.getMemberIds());
     }
 
     public void validateUpdateRequest(final GroupUpdateRequest request) {
@@ -40,10 +40,13 @@ public class GroupValidator {
 //    }
 
     private void validateDuplicateIds(
+            final Long ownerId,
             final List<Long> managerIds,
             final List<Long> memberIds
     ) {
         final Set<Long> set = new HashSet<>();
+        set.add(ownerId);
+
         if (managerIds != null) {
             for (Long id : managerIds) {
                 if (set.contains(id)) {

--- a/src/main/resources/mybatis/mapper/GroupMapper.xml
+++ b/src/main/resources/mybatis/mapper/GroupMapper.xml
@@ -55,6 +55,7 @@
             name = #{title},
             description = #{description},
             visibility = #{visibility},
+            owner_id = #{ownerId},
             updated_at = #{updatedAt}
         WHERE id = #{id}
     </update>


### PR DESCRIPTION
이슈번호: https://github.com/cheonggangsan/BlueStrongMountain_backend/issues/29
---
## 📂 주요 변경 사항

### 1. Controller – RequestBody DTO 분리

기존에 `@RequestBody List<Long>` 또는 `@RequestBody Long` 형태로 받던 요청을

**의미 있는 DTO로 통일**했습니다.

### 변경 예시

- 그룹 소유자 변경
- 매니저 추가
- 멤버 추가

```java
@RequestBody GroupChangeOwnerRequest
@RequestBody GroupAddIdsRequest
```

### 도입된 DTO

- `GroupChangeOwnerRequest`
- `GroupAddIdsRequest`

→ 요청 구조 명확화 및 향후 필드 확장 가능

---

### 2. UserGroupRepository – save 제거, 역할 분리

기존 `save()` 메서드는

- 신규 INSERT
- 역할 UPDATE

를 동시에 처리하고 있어 책임이 불명확하고 중복 INSERT 위험이 있었습니다.

### 변경 내용

- `save()` 제거
- `insert(UserGroup)`
- `updateRole(UserGroup)` 명확 분리

이를 통해:

- Repository 책임 명확화
- 비즈니스 분기는 Service 레벨에서 처리

---

### 3. Service 레이어 정리

### GroupMemberServiceImpl

- 매니저 추가/삭제
- 멤버 추가

에서:

- 신규 멤버 → `insert`
- 역할 변경 → `updateRole`

로 명확히 분리

### GroupServiceImpl

- 그룹 생성 시 OWNER / MANAGER / MEMBER insert 로직 명확화
- owner 변경 시:
    - 그룹 엔티티 owner 갱신
    - 기존 OWNER → MEMBER
    - 신규 OWNER → OWNER
    - 역할 변경은 `updateRole`로 처리

---

### 4. Group 도메인 보강

- `@Getter`, `@ToString` 추가
- owner 변경 시점(`updatedAt`) 관리 로직 유지

---

## 🧪 동작 흐름 (Owner 변경)

1. 요청 DTO로 newOwnerId 수신
2. 권한 검증 (`validateOwnerTransferable`)
3. Group 엔티티 owner 변경 및 저장
4. 기존 OWNER → MEMBER (updateRole)
5. 신규 OWNER → OWNER (updateRole)

→ **중복 INSERT 없이 역할만 변경**

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 그룹 API 요청이 더 구조화된 형식으로 바뀌어 일관성 있고 안정적으로 처리됩니다.
  * 그룹 생성 시 중복 검사에 소유자 ID가 포함되어 중복 방지가 강화되었습니다.

* **Bug Fixes**
  * 그룹 구성원 수 집계가 멤버·관리자·소유자를 모두 합산하도록 수정되어 통계가 정확해졌습니다.
  * 소유권 이전 및 역할 업데이트 흐름이 개선되어 소유자 변경 시 역할 반영이 더 정확해졌습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->