### PR TITLE
[BST-32] solved.ac 연동을 통한 사용자 풀이 문제 동기화 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ dependencies {
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.5'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
 
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/src/main/java/com/ssafy/BlueStrongMountain/config/WebClientConfig.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/config/WebClientConfig.java
@@ -1,0 +1,13 @@
+package com.ssafy.BlueStrongMountain.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+    @Bean
+    public WebClient webClient() {
+        return WebClient.builder().build();
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/controller/SolvedAcController.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/controller/SolvedAcController.java
@@ -39,7 +39,7 @@ public class SolvedAcController {
      * 유저가 푼 문제 ID 목록 조회
      *
      * 예:
-     * GET /api/v1/user-solutions/solved?userId=1
+     * GET /api/test/solvedac/solved?userId=1
      */
     @GetMapping("/solved")
     public ResponseEntity<Set<Long>> getSolvedProblemIds(

--- a/src/main/java/com/ssafy/BlueStrongMountain/controller/SolvedAcController.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/controller/SolvedAcController.java
@@ -1,0 +1,52 @@
+package com.ssafy.BlueStrongMountain.controller;
+
+import com.ssafy.BlueStrongMountain.domain.UserSolution;
+import com.ssafy.BlueStrongMountain.service.SolvedAcSyncService;
+import com.ssafy.BlueStrongMountain.service.UserSolutionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/test/solvedac")
+public class SolvedAcController {
+
+    private final SolvedAcSyncService solvedAcSyncService;
+    private final UserSolutionService userSolutionService;
+
+
+    /**
+     * solved.ac 동기화 테스트
+     *
+     * 예:
+     * POST /api/test/solvedac/sync?userId=1
+     */
+    @PostMapping("/sync")
+    public ResponseEntity<Void> syncSolvedAc(
+            @RequestParam Long userId
+    ) {
+        solvedAcSyncService.syncUserSolution(userId);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 유저가 푼 문제 ID 목록 조회
+     *
+     * 예:
+     * GET /api/v1/user-solutions/solved?userId=1
+     */
+    @GetMapping("/solved")
+    public ResponseEntity<Set<Long>> getSolvedProblemIds(
+            @RequestParam Long userId
+    ) {
+        return ResponseEntity.ok(
+                new HashSet<>(userSolutionService.findSolvedProblemIds(userId))
+        );
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/SolvedAcProblem.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/SolvedAcProblem.java
@@ -1,0 +1,10 @@
+package com.ssafy.BlueStrongMountain.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SolvedAcProblem {
+    private Long problemId;
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/SolvedAcResponse.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/SolvedAcResponse.java
@@ -1,0 +1,15 @@
+package com.ssafy.BlueStrongMountain.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@ToString
+public class SolvedAcResponse {
+    private int count;
+    private List<SolvedAcProblem> items;
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/SolvedAcSyncService.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/SolvedAcSyncService.java
@@ -1,0 +1,18 @@
+package com.ssafy.BlueStrongMountain.service;
+
+import java.util.Set;
+
+public interface SolvedAcSyncService {
+    /**
+     * solved.ac API를 조회하여
+     * user_solution 테이블을 최신 상태로 동기화한다.
+     *
+     * @param userId 내부 사용자 ID
+     */
+    void syncUserSolution(Long userId);
+
+    /**
+     * user_solution 기준으로 solved problem ids 조회
+     */
+    Set<Long> getSolvedProblemIds(Long userId);
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/SolvedAcSyncServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/SolvedAcSyncServiceImpl.java
@@ -44,6 +44,9 @@ public class SolvedAcSyncServiceImpl implements SolvedAcSyncService{
         int page = 1;
         int totalCount = Integer.MAX_VALUE;
 
+        Set<Long> existingSolvedProblemIds = getSolvedProblemIds(userId);
+
+
         while((page - 1) * PAGE_SIZE < totalCount) {
             int finalPage = page;
             SolvedAcResponse response = webClient.get()
@@ -61,11 +64,10 @@ public class SolvedAcSyncServiceImpl implements SolvedAcSyncService{
 
 
 
-                if(userSolutionRepository
-                        .findByUserAndProblem(userId, problemId)
-                        .isPresent()){
+                if(existingSolvedProblemIds.contains(problemId)){
                     continue;
                 }
+
                 //DB에 userSolution 저장 로직
                 userSolutionRepository.save(
                         UserSolution.create(

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/SolvedAcSyncServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/SolvedAcSyncServiceImpl.java
@@ -44,8 +44,6 @@ public class SolvedAcSyncServiceImpl implements SolvedAcSyncService{
         int page = 1;
         int totalCount = Integer.MAX_VALUE;
 
-        List<Long> testProblemIds = new ArrayList<>();//test
-
         while((page - 1) * PAGE_SIZE < totalCount) {
             int finalPage = page;
             SolvedAcResponse response = webClient.get()
@@ -62,7 +60,6 @@ public class SolvedAcSyncServiceImpl implements SolvedAcSyncService{
                 Long problemId = item.getProblemId();
 
 
-                testProblemIds.add(problemId);//test
 
                 if(userSolutionRepository
                         .findByUserAndProblem(userId, problemId)
@@ -81,7 +78,6 @@ public class SolvedAcSyncServiceImpl implements SolvedAcSyncService{
             page++;
         }
 
-//        //test
 //        System.out.println(testProblemIds.size());
 //        for(Long pid : testProblemIds){
 //            System.out.print(pid + " ");
@@ -89,7 +85,6 @@ public class SolvedAcSyncServiceImpl implements SolvedAcSyncService{
 //        System.out.println();
 //
 //
-//        //test
 
     }
 

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/SolvedAcSyncServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/SolvedAcSyncServiceImpl.java
@@ -1,0 +1,104 @@
+package com.ssafy.BlueStrongMountain.service;
+
+import com.ssafy.BlueStrongMountain.domain.User;
+import com.ssafy.BlueStrongMountain.domain.UserSolution;
+import com.ssafy.BlueStrongMountain.dto.SolvedAcProblem;
+import com.ssafy.BlueStrongMountain.dto.SolvedAcResponse;
+import com.ssafy.BlueStrongMountain.repository.UserRepository;
+import com.ssafy.BlueStrongMountain.repository.UserSolutionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SolvedAcSyncServiceImpl implements SolvedAcSyncService{
+    private static final String SOLVED_AC_URL =
+            "https://solved.ac/api/v3/search/problem";
+
+    private static final int PAGE_SIZE = 50;
+
+    private final UserRepository userRepository;
+    private final UserSolutionRepository userSolutionRepository;
+    private final WebClient webClient;
+
+    @Override
+    public void syncUserSolution(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found!"));
+
+        String handle = user.getBaekjoonHandle();
+        if(handle == null || handle.isBlank()){
+            return;
+        }
+
+        int page = 1;
+        int totalCount = Integer.MAX_VALUE;
+
+        List<Long> testProblemIds = new ArrayList<>();//test
+
+        while((page - 1) * PAGE_SIZE < totalCount) {
+            int finalPage = page;
+            SolvedAcResponse response = webClient.get()
+                    .uri(SOLVED_AC_URL + "?query=s@" + handle + "&page=" + finalPage)
+                    .retrieve()
+                    .bodyToMono(SolvedAcResponse.class)
+                    .block();
+
+            if(response == null || response.getItems().isEmpty()){
+                break;
+            }
+            totalCount = response.getCount();
+            for(SolvedAcProblem item : response.getItems()){
+                Long problemId = item.getProblemId();
+
+
+                testProblemIds.add(problemId);//test
+
+                if(userSolutionRepository
+                        .findByUserAndProblem(userId, problemId)
+                        .isPresent()){
+                    continue;
+                }
+                //DB에 userSolution 저장 로직
+                userSolutionRepository.save(
+                        UserSolution.create(
+                                userId,
+                                problemId,
+                                LocalDateTime.now()
+                        )
+                );
+            }
+            page++;
+        }
+
+//        //test
+//        System.out.println(testProblemIds.size());
+//        for(Long pid : testProblemIds){
+//            System.out.print(pid + " ");
+//        }
+//        System.out.println();
+//
+//
+//        //test
+
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Set<Long> getSolvedProblemIds(Long userId) {
+        return userSolutionRepository.findByUserId(userId)
+                .stream()
+                .map(UserSolution::getProblemId)
+                .collect(Collectors.toSet());
+    }
+}


### PR DESCRIPTION
이슈번호: https://github.com/cheonggangsan/BlueStrongMountain_backend/issues/32
---

다음 정도로 **짧고 깔끔한 PR 설명**이면 충분합니다.

---

## 주요 변경 사항

* **Config**

  * `WebClientConfig` 추가하여 외부 API 호출 환경 구성
* **Service**

  * `SolvedAcSyncService` 및 구현체 추가
  * solved.ac 검색 API를 페이지 단위로 조회하여 신규 풀이 문제만 저장
* **Controller**

  * solved.ac 동기화 테스트용 API 추가
  * 사용자 풀이 문제 ID 조회 API 제공
* **Dependency**

  * `spring-boot-starter-webflux` 추가 (WebClient 사용 목적)

## API

* `POST /api/test/solvedac/sync?userId={id}`
  → solved.ac 기준 사용자 풀이 문제 동기화
* `GET /api/test/solvedac/solved?userId={id}`
  → 사용자가 푼 문제 ID 목록 조회



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Solved.ac와 연동해 사용자의 해결한 문제 목록을 서버에 동기화하는 기능(동기화 요청 API) 추가.
  * 특정 사용자의 해결한 문제 ID 목록을 조회하는 API 엔드포인트 추가.

* **기타**
  * 외부 문제 정보 연동을 위한 구성 및 서비스 로직이 도입되어 연동 안정성이 향상되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->