### PR TITLE
[BST-35] Board 마감 시간 정책 도입 및 BoardUserProgress 연계 로직 안정화

### DIFF
--- a/src/main/java/com/ssafy/BlueStrongMountain/domain/Board.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/domain/Board.java
@@ -1,5 +1,6 @@
 package com.ssafy.BlueStrongMountain.domain;
 
+import com.ssafy.BlueStrongMountain.domain.policy.BoardTimePolicy;
 import lombok.Getter;
 import java.time.LocalDateTime;
 
@@ -51,6 +52,10 @@ public final class Board {
 
         LocalDateTime now = LocalDateTime.now();
 
+        LocalDateTime resolvedEndTime =
+                endTime != null ? endTime : BoardTimePolicy.NO_DEADLINE;
+
+
         return new Board(
                 null,
                 groupId,
@@ -58,7 +63,7 @@ public final class Board {
                 title,
                 content,
                 now,
-                endTime,
+                resolvedEndTime,
                 0,
                 now,
                 null
@@ -83,6 +88,9 @@ public final class Board {
 
     // 수정: 불변 객체 → 수정 시 새 객체를 리턴하는 방식
     public Board update(String title, LocalDateTime endTime, String content) {
+        LocalDateTime resolvedEndTime =
+                endTime != null ? endTime : BoardTimePolicy.NO_DEADLINE;
+
         return new Board(
                 this.id,
                 this.groupId,
@@ -90,7 +98,7 @@ public final class Board {
                 title,
                 content,
                 this.startTime,
-                endTime,
+                resolvedEndTime,
                 this.viewCount,
                 this.createdAt,
                 LocalDateTime.now()

--- a/src/main/java/com/ssafy/BlueStrongMountain/domain/policy/BoardTimePolicy.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/domain/policy/BoardTimePolicy.java
@@ -1,0 +1,9 @@
+package com.ssafy.BlueStrongMountain.domain.policy;
+
+import java.time.LocalDateTime;
+
+public class BoardTimePolicy {
+    private BoardTimePolicy(){}
+    public static final LocalDateTime NO_DEADLINE
+            = LocalDateTime.of(9999, 12, 31, 23, 59, 59);
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/BoardCreateRequest.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/BoardCreateRequest.java
@@ -1,6 +1,7 @@
 package com.ssafy.BlueStrongMountain.dto;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 import java.time.LocalDateTime;
@@ -8,6 +9,7 @@ import java.util.List;
 
 @Getter
 @ToString
+@NoArgsConstructor
 public class BoardCreateRequest {
     private String title;
     private LocalDateTime endTime;

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/BoardUpdateRequest.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/BoardUpdateRequest.java
@@ -1,6 +1,7 @@
 package com.ssafy.BlueStrongMountain.dto;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 import java.time.LocalDateTime;
@@ -8,6 +9,7 @@ import java.util.List;
 
 @Getter
 @ToString
+@NoArgsConstructor
 public class BoardUpdateRequest {
     private String title;
     private LocalDateTime endTime;

--- a/src/main/java/com/ssafy/BlueStrongMountain/exception/BoardNotFoundException.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/exception/BoardNotFoundException.java
@@ -1,0 +1,4 @@
+package com.ssafy.BlueStrongMountain.exception;
+
+public class BoardNotFoundException extends RuntimeException{
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/BoardApplicationServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/BoardApplicationServiceImpl.java
@@ -39,9 +39,8 @@ public class BoardApplicationServiceImpl implements BoardApplicationService{
             BoardCreateRequest req) {
 
         //groupId 검증
-        if(!groupRepository.findById(groupId).isPresent()){
-            throw new GroupNotFoundException(groupId);
-        }
+        validateGroupExists(groupId);
+
 
         if(req.getEndTime() != null && LocalDateTime.now().isAfter(req.getEndTime())){
             throw new RuntimeException("Deadline should not be in the past");
@@ -67,7 +66,6 @@ public class BoardApplicationServiceImpl implements BoardApplicationService{
             Long requesterId,
             Long groupId,
             Long boardId) {
-        //groupId에 대한 로직이 따로 없음
 
         List<BoardUserProgress> progresses =
                 boardUserProgressService.getProgressByBoard(boardId);
@@ -118,9 +116,7 @@ public class BoardApplicationServiceImpl implements BoardApplicationService{
             Long boardId,
             BoardUpdateRequest req) {
         //groupId 검증
-        if(!groupRepository.findById(groupId).isPresent()){
-            throw new GroupNotFoundException(groupId);
-        }
+        validateGroupExists(groupId);
 
         BoardDetailResponse findBoard = boardService.getBoard(groupId, boardId);
 
@@ -166,9 +162,8 @@ public class BoardApplicationServiceImpl implements BoardApplicationService{
             Long groupId,
             Long boardId) {
         //groupId 검증
-        if(!groupRepository.findById(groupId).isPresent()){
-            throw new GroupNotFoundException(groupId);
-        }
+        validateGroupExists(groupId);
+
         boardUserProgressService.deleteByBoard(boardId);
 
         boardService.deleteBoard(
@@ -207,6 +202,12 @@ public class BoardApplicationServiceImpl implements BoardApplicationService{
                         problemId
                 );
             }
+        }
+    }
+
+    private void validateGroupExists(Long groupId){
+        if(!groupRepository.findById(groupId).isPresent()){
+            throw new GroupNotFoundException(groupId);
         }
     }
 }

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/BoardApplicationServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/BoardApplicationServiceImpl.java
@@ -4,8 +4,10 @@ import com.ssafy.BlueStrongMountain.domain.BoardProblem;
 import com.ssafy.BlueStrongMountain.domain.BoardUserProgress;
 import com.ssafy.BlueStrongMountain.domain.BoardUserStatus;
 import com.ssafy.BlueStrongMountain.dto.*;
+import com.ssafy.BlueStrongMountain.exception.GroupNotFoundException;
 import com.ssafy.BlueStrongMountain.repository.BoardProblemRepository;
 import com.ssafy.BlueStrongMountain.repository.BoardUserProgressRepository;
+import com.ssafy.BlueStrongMountain.repository.GroupRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +24,7 @@ public class BoardApplicationServiceImpl implements BoardApplicationService{
     private final BoardUserProgressService boardUserProgressService;
 
     private final BoardProblemRepository boardProblemRepository;
+    private final GroupRepository groupRepository;
 
 
     private final BoardUserProgressRepository boardUserProgressRepository;
@@ -35,7 +38,12 @@ public class BoardApplicationServiceImpl implements BoardApplicationService{
             Long groupId,
             BoardCreateRequest req) {
 
-        if(LocalDateTime.now().isAfter(req.getEndTime())){
+        //groupId 검증
+        if(!groupRepository.findById(groupId).isPresent()){
+            throw new GroupNotFoundException(groupId);
+        }
+
+        if(req.getEndTime() != null && LocalDateTime.now().isAfter(req.getEndTime())){
             throw new RuntimeException("Deadline should not be in the past");
         }
 
@@ -59,6 +67,8 @@ public class BoardApplicationServiceImpl implements BoardApplicationService{
             Long requesterId,
             Long groupId,
             Long boardId) {
+        //groupId에 대한 로직이 따로 없음
+
         List<BoardUserProgress> progresses =
                 boardUserProgressService.getProgressByBoard(boardId);
 
@@ -107,12 +117,17 @@ public class BoardApplicationServiceImpl implements BoardApplicationService{
             Long groupId,
             Long boardId,
             BoardUpdateRequest req) {
+        //groupId 검증
+        if(!groupRepository.findById(groupId).isPresent()){
+            throw new GroupNotFoundException(groupId);
+        }
 
         BoardDetailResponse findBoard = boardService.getBoard(groupId, boardId);
+
         if (LocalDateTime.now().isAfter(findBoard.getEndTime())) {
             throw new RuntimeException("Deadline passed. Cannot update.");
         }
-        if(LocalDateTime.now().isAfter(req.getEndTime())){
+        if(req.getEndTime() != null && LocalDateTime.now().isAfter(req.getEndTime())){
             throw new RuntimeException("End time must be after current time");
         }
 
@@ -150,6 +165,10 @@ public class BoardApplicationServiceImpl implements BoardApplicationService{
             Long requesterId,
             Long groupId,
             Long boardId) {
+        //groupId 검증
+        if(!groupRepository.findById(groupId).isPresent()){
+            throw new GroupNotFoundException(groupId);
+        }
         boardUserProgressService.deleteByBoard(boardId);
 
         boardService.deleteBoard(

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/BoardServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/BoardServiceImpl.java
@@ -3,6 +3,7 @@ package com.ssafy.BlueStrongMountain.service;
 import com.ssafy.BlueStrongMountain.domain.Board;
 import com.ssafy.BlueStrongMountain.domain.BoardProblem;
 import com.ssafy.BlueStrongMountain.dto.*;
+import com.ssafy.BlueStrongMountain.exception.BoardNotFoundException;
 import com.ssafy.BlueStrongMountain.repository.BoardProblemRepository;
 import com.ssafy.BlueStrongMountain.repository.BoardRepository;
 import com.ssafy.BlueStrongMountain.repository.BoardUserProgressRepository;
@@ -59,7 +60,8 @@ public class BoardServiceImpl implements BoardService{
     @Override
     public BoardDetailResponse getBoard(Long groupId, Long boardId) {
         Board board = boardRepository.findById(boardId)
-                .orElseThrow(() -> new RuntimeException("Board not found"));
+                //.orElseThrow(() -> new RuntimeException("Board not found"));
+                .orElseThrow(BoardNotFoundException::new);
 
         List<Long> problemIds = boardProblemRepository.findByBoardId(boardId)
                 .stream()
@@ -80,9 +82,9 @@ public class BoardServiceImpl implements BoardService{
         Board currentBoard = boardRepository.findById(boardId)
                 .orElseThrow(() -> new RuntimeException("Board not found"));
 
-        if (LocalDateTime.now().isAfter(currentBoard.getEndTime())) {
-            throw new RuntimeException("Deadline passed. Cannot update.");
-        }
+//        if (LocalDateTime.now().isAfter(currentBoard.getEndTime())) {
+//            throw new RuntimeException("Deadline passed. Cannot update.");
+//        }
 
         // Immutable → 수정된 새 객체를 생성
         Board updatedBoard = currentBoard.update(

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/BoardServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/BoardServiceImpl.java
@@ -80,7 +80,7 @@ public class BoardServiceImpl implements BoardService{
     @Override
     public void updateBoard(Long requesterId, Long groupId, Long boardId, BoardUpdateRequest request) {
         Board currentBoard = boardRepository.findById(boardId)
-                .orElseThrow(() -> new RuntimeException("Board not found"));
+                .orElseThrow(BoardNotFoundException::new);
 
 //        if (LocalDateTime.now().isAfter(currentBoard.getEndTime())) {
 //            throw new RuntimeException("Deadline passed. Cannot update.");


### PR DESCRIPTION
이슈번호: https://github.com/cheonggangsan/BlueStrongMountain_backend/issues/35
---

## PR 설명

### Board 마감 시간 정책 개선

#### 🔹 문제점

* `endTime`이 `null`인 경우, 서비스 단에서 시간 비교(`isAfter`) 시 NPE 발생
* 예외 발생 시점이 트랜잭션 경계 이후가 되어 DB 반영이 남는 문제 발생

#### 🔹 해결

* `BoardTimePolicy`를 도입하여 **마감 없음(NO_DEADLINE)** 을 의미하는 기본 시간을 정의

  * `9999-12-31 23:59:59`
* `Board.create`, `Board.update` 시점에서 `null` endTime을 정책 값으로 치환
* Board 도메인은 **항상 null이 아닌 endTime을 가지도록 보장**

```text
null endTime → NO_DEADLINE
```

이를 통해:

* 모든 시간 비교 로직에서 NPE 가능성 제거
* 서비스/도메인 로직 단순화

---

### DTO 설계 방향 정리

* `BoardCreateRequest`, `BoardUpdateRequest`는 **입력 DTO 역할만 유지**
* `endTime`은 `null` 허용
* 실제 기본값 적용은 **도메인 계층(Board)** 에서 처리

DTO는 값 보관 역할에 집중하고,
비즈니스 정책은 도메인으로 일원화하였습니다.

---

### BoardApplicationService 안정화

#### 🔹 추가된 검증

* `groupId` 존재 여부 검증
* 보드 수정 시:

  * 이미 마감된 보드는 수정 불가
  * 새로 설정하려는 `endTime`이 과거인 경우 예외 발생

#### 🔹 보드 수정 흐름

1. 기존 보드 문제 목록 조회
2. 수정 요청 문제 목록과 diff 계산
3. BoardService에서 보드 및 문제 업데이트
4. BoardUserProgressService에서

   * 추가된 문제 → 진행 상태 초기화
   * 제거된 문제 → 해당 progress 삭제

---

### 예외 처리 개선

* `BoardNotFoundException` 도입
* 기존 `RuntimeException` 기반 처리 일부를 명확한 도메인 예외로 교체


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 그룹 존재 검증 추가로 보드 생성/수정/삭제 시 안정성 강화
  * 지정되지 않은 마감에 대한 표준 장기 만료값 도입
  * DTO 호환성 강화를 위한 기본 생성자 지원 추가
  * 전용 "보드 미존재" 예외 도입으로 오류 의미 명확화

* **Bug Fixes**
  * null 마감일에 대한 안전한 처리로 예외 감소
  * 작업 전 그룹 존재 확인을 통한 사전 검증 보강

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->