### PR TITLE
[BST-40] feat: 유저 검색 API 추가 (username/email 부분 검색)

### DIFF
--- a/src/main/java/com/ssafy/BlueStrongMountain/controller/UserController.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/controller/UserController.java
@@ -1,13 +1,12 @@
 package com.ssafy.BlueStrongMountain.controller;
 
-import com.ssafy.BlueStrongMountain.dto.BaseResponse;
-import com.ssafy.BlueStrongMountain.dto.ChangePasswordRequest;
-import com.ssafy.BlueStrongMountain.dto.ChangeUsernameRequest;
-import com.ssafy.BlueStrongMountain.dto.UserInfoResponse;
+import com.ssafy.BlueStrongMountain.dto.*;
 import com.ssafy.BlueStrongMountain.service.UserService;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/users")
@@ -18,6 +17,13 @@ public class UserController {
     @GetMapping("/{id}")
     public ResponseEntity<UserInfoResponse> get(@PathVariable Long id) {
         return ResponseEntity.ok(userService.getUser(id));
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<List<UserSimpleDto>> getUsersByKeyword(
+            @RequestParam String query
+    ){
+        return ResponseEntity.ok(userService.searchUsersByKeyword(query));
     }
 
     @PatchMapping("/{id}/username")

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/UserSimpleDto.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/UserSimpleDto.java
@@ -1,0 +1,23 @@
+package com.ssafy.BlueStrongMountain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@NoArgsConstructor
+@ToString
+public class UserSimpleDto {
+    private Long id;
+    private String email;
+    private String username;
+
+    public static UserSimpleDto from(Long id, String email, String username){
+        UserSimpleDto dto = new UserSimpleDto();
+        dto.id = id;
+        dto.username = username;
+        dto.email = email;
+        return dto;
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/UserRepository.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/UserRepository.java
@@ -2,6 +2,7 @@ package com.ssafy.BlueStrongMountain.repository;
 
 import com.ssafy.BlueStrongMountain.domain.User;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository {
@@ -9,5 +10,7 @@ public interface UserRepository {
     Optional<User> findByEmail(String email);
     Optional<User> findById(Long id);
     Optional<User> findByUsername(String username);
+    List<User> searchByEmail(String keyword);
+    List<User> searchByUsername(String keyword);
     void delete(Long id);
 }

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/UserRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.ssafy.BlueStrongMountain.repository.mapper.UserMapper;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -31,6 +32,16 @@ public class UserRepositoryImpl implements UserRepository{
     @Override
     public Optional<User> findByUsername(String username) {
         return Optional.ofNullable(mapper.findByUsername(username));
+    }
+
+    @Override
+    public List<User> searchByEmail(String keyword) {
+        return mapper.searchByEmail(keyword);
+    }
+
+    @Override
+    public List<User> searchByUsername(String keyword) {
+        return mapper.searchByUsername(keyword);
     }
 
     @Override

--- a/src/main/java/com/ssafy/BlueStrongMountain/repository/mapper/UserMapper.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/repository/mapper/UserMapper.java
@@ -4,6 +4,8 @@ import com.ssafy.BlueStrongMountain.domain.User;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+import java.util.List;
+
 @Mapper
 public interface UserMapper {
     void insert(User user);
@@ -15,6 +17,10 @@ public interface UserMapper {
     User findByEmail(@Param("email") String email);
 
     User findByUsername(@Param("username") String username);
+
+    List<User> searchByEmail(@Param("keyword") String keyword);
+
+    List<User> searchByUsername(@Param("keyword") String keyword);
 
     void delete(@Param("id") Long id);
 }

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/UserService.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/UserService.java
@@ -1,9 +1,13 @@
 package com.ssafy.BlueStrongMountain.service;
 
 import com.ssafy.BlueStrongMountain.dto.UserInfoResponse;
+import com.ssafy.BlueStrongMountain.dto.UserSimpleDto;
+
+import java.util.List;
 
 public interface UserService {
     public UserInfoResponse getUser(Long userId);
+    public List<UserSimpleDto> searchUsersByKeyword(String keyword);
     public void changeUsername(Long userId, String newName);
     public void changePassword(Long userId, String newPw);
     public void deleteUser(Long userId);

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/UserServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/UserServiceImpl.java
@@ -2,6 +2,7 @@ package com.ssafy.BlueStrongMountain.service;
 
 import com.ssafy.BlueStrongMountain.domain.User;
 import com.ssafy.BlueStrongMountain.dto.UserInfoResponse;
+import com.ssafy.BlueStrongMountain.dto.UserSimpleDto;
 import com.ssafy.BlueStrongMountain.exception.InvalidPasswordException;
 import com.ssafy.BlueStrongMountain.exception.UserHasGroupException;
 import com.ssafy.BlueStrongMountain.exception.UserNotFoundException;
@@ -10,6 +11,11 @@ import com.ssafy.BlueStrongMountain.repository.UserRepository;
 import lombok.AllArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Service
 @AllArgsConstructor
@@ -28,6 +34,35 @@ public class UserServiceImpl implements UserService{
                 user.getStatus().name(), user.getCreatedAt(), user.getUpdatedAt()
         );
     }
+
+    @Override
+    public List<UserSimpleDto> searchUsersByKeyword(String keyword) {
+        List<UserSimpleDto> ret = new ArrayList<>();
+
+        Map<Long, UserSimpleDto> resultMap = new HashMap<>();
+
+        userRepository.searchByUsername(keyword)
+                .forEach(u -> resultMap.put(
+                        u.getId(),
+                        UserSimpleDto.from(
+                                u.getId(),
+                                u.getEmail(),
+                                u.getUsername()
+                        )
+                ));
+        userRepository.searchByEmail(keyword)
+                .forEach(u -> resultMap.put(
+                        u.getId(),
+                        UserSimpleDto.from(
+                                u.getId(),
+                                u.getEmail(),
+                                u.getUsername()
+                        )
+                ));
+
+        return new ArrayList<>(resultMap.values());
+    }
+
 
     @Override
     public void changeUsername(Long userId, String newName) {

--- a/src/main/resources/mybatis/mapper/UserMapper.xml
+++ b/src/main/resources/mybatis/mapper/UserMapper.xml
@@ -45,6 +45,14 @@
     <select id="findByEmail" resultMap="UserResultMap">
         SELECT * FROM users WHERE email = #{email}
     </select>
+    
+    <select id="searchByEmail" resultMap="UserResultMap">
+        SELECT * FROM users WHERE email LIKE CONCAT('%', #{keyword}, '%')
+    </select>
+
+    <select id="searchByUsername" resultMap="UserResultMap">
+        SELECT * FROM users WHERE email LIKE CONCAT('%', #{keyword}, '%')
+    </select>
 
     <select id="findByUsername" resultMap="UserResultMap">
         SELECT * FROM users WHERE username = #{username}

--- a/src/main/resources/mybatis/mapper/UserMapper.xml
+++ b/src/main/resources/mybatis/mapper/UserMapper.xml
@@ -51,7 +51,7 @@
     </select>
 
     <select id="searchByUsername" resultMap="UserResultMap">
-        SELECT * FROM users WHERE email LIKE CONCAT('%', #{keyword}, '%')
+        SELECT * FROM users WHERE username LIKE CONCAT('%', #{keyword}, '%')
     </select>
 
     <select id="findByUsername" resultMap="UserResultMap">

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -128,6 +128,34 @@ paths:
               schema:
                 $ref: '#/components/schemas/BaseResponse'
 
+  /api/v1/users/search:
+    get:
+      tags:
+        [User]
+      summary: Search users by keyword
+      description: >
+        username 또는 email에 대해 부분 일치 검색을 수행합니다.
+        검색 결과로는 id, username, email만 반환합니다.
+      parameters:
+        - in: query
+          name: query
+          required: true
+          schema:
+            type: string
+          description: 검색 키워드 (username 또는 email)
+          example: "abc"
+      responses:
+        '200':
+          description: Search result
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/UserSimpleDto'
+        '400':
+          description: Invalid query parameter
+
 
   /api/v1/users/{id}/username:
     patch:
@@ -1145,6 +1173,20 @@ components:
         password:
           type: string
           example: newPassword123
+
+    UserSimpleDto:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 1
+        username:
+          type: string
+          example: "fermat001"
+        email:
+          type: string
+          example: "fermat001@gmail.com"
 
       ############################################################
     # Group DTOs


### PR DESCRIPTION
이슈번호: https://github.com/cheonggangsan/BlueStrongMountain_backend/issues/40
---

### ✅ 구현 내용

* username 또는 email 기준으로 유저를 검색하는 API 추가
* 검색 결과로 `id`, `username`, `email`만 반환하는 전용 DTO(`UserSimpleDto`) 도입
* 검색 결과 중복 제거 로직(id 기준) 구현
* REST 규칙에 맞는 검색 URI(`/api/v1/users/search`) 추가

---

### 📂 변경 모듈

* `UserController`
* `UserService`, `UserServiceImpl`
* `UserRepository`, `UserRepositoryImpl`
* `UserMapper`, `UserMapper.xml`
* `UserSimpleDto`

---

### 🧪 동작 흐름

1. 클라이언트가 `/api/v1/users/search?query={keyword}` 요청
2. Service에서 username 검색 + email 검색을 각각 수행
3. 검색 결과를 id 기준으로 병합하여 중복 제거
4. `UserSimpleDto(id, username, email)` 형태로 응답 반환

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 사용자 검색 기능이 추가되었습니다. 이제 키워드를 사용하여 사용자명이나 이메일로 다른 사용자를 검색할 수 있습니다. 새로운 검색 API 엔드포인트가 기본 사용자 정보와 함께 검색 결과를 반환합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->