### PR TITLE
[BST-42] refactor: BoardResponse에 문제 수 필드 추가

### DIFF
--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/BoardResponse.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/BoardResponse.java
@@ -11,10 +11,12 @@ public class BoardResponse {
     private Long boardId;
     private String title;
     private LocalDateTime endTime;
+    private int problemsCount;
 
-    public BoardResponse(Long boardId, String title, LocalDateTime endTime) {
+    public BoardResponse(Long boardId, String title, LocalDateTime endTime, int problemsCount) {
         this.boardId = boardId;
         this.title = title;
         this.endTime = endTime;
+        this.problemsCount = problemsCount;
     }
 }

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/BoardServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/BoardServiceImpl.java
@@ -54,7 +54,7 @@ public class BoardServiceImpl implements BoardService{
 
         // (검색 조건은 이후 QueryDSL 또는 필터 로직 추가)
         return boards.stream()
-                .map(b -> new BoardResponse(b.getId(), b.getTitle(), b.getEndTime()))
+                .map(b -> new BoardResponse(b.getId(), b.getTitle(), b.getEndTime(), boardProblemRepository.findByBoardId(b.getId()).size()))
                 .collect(Collectors.toList());
     }
     @Override


### PR DESCRIPTION
이슈번호: https://github.com/cheonggangsan/BlueStrongMountain_backend/issues/42
---

### ✅ 변경 내용

* `BoardResponse`에 게시판에 포함된 문제 개수를 나타내는 `problemsCount` 필드 추가
* 이에 따라 `BoardResponse` 생성자 시그니처를 확장
* 보드 목록 조회 시 각 보드별 문제 개수를 함께 반환하도록 로직 수정

---

### 📂 변경 파일

* `BoardResponse`
* `BoardServiceImpl`

---

### 🧪 동작 흐름

1. 그룹 내 보드 목록 조회
2. 각 보드에 대해:

   * `boardId`, `title`, `endTime` 조회
   * 해당 보드에 연결된 문제 개수 조회
3. `BoardResponse(boardId, title, endTime, problemsCount)` 형태로 응답 반환

---

### 💡 설계 의도

* 보드 목록 화면에서 **문제 개수 정보를 즉시 제공**하기 위함
* 클라이언트에서 추가 API 호출 없이도 보드 요약 정보를 구성 가능
* 기존 응답 구조를 크게 변경하지 않고 필드 확장 방식으로 대응

---

### ⚠️ 참고 사항

* 현재는 보드마다 `boardProblemRepository.findByBoardId()`를 호출하는 구조
* 보드 수가 많아질 경우 **N+1 이슈 가능성**이 있어,
  추후 `JOIN + COUNT` 쿼리 또는 배치 조회로 개선 예정

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능
* 게시판 목록에 각 게시판의 문제 개수 정보를 표시합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->