### PR TITLE
[BST-45] refactoring: board detail 응답에 문제 요약 DTO 추가

### DIFF
--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/BoardDetailResponse.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/BoardDetailResponse.java
@@ -1,5 +1,6 @@
 package com.ssafy.BlueStrongMountain.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -8,20 +9,23 @@ import java.util.List;
 
 @Getter
 @ToString
+@AllArgsConstructor
 public class BoardDetailResponse {
 
     private Long boardId;
     private String title;
     private LocalDateTime startTime;
     private LocalDateTime endTime;
-    private List<Long> problemIds;
+    //private List<Long> problemIds;
+    private List<ProblemSimpleDto> problems;
 
-    public BoardDetailResponse(Long boardId, String title, LocalDateTime startTime,
-                               LocalDateTime endTime, List<Long> problemIds) {
-        this.boardId = boardId;
-        this.title = title;
-        this.startTime = startTime;
-        this.endTime = endTime;
-        this.problemIds = problemIds;
-    }
+
+//    public BoardDetailResponse(Long boardId, String title, LocalDateTime startTime,
+//                               LocalDateTime endTime, List<Long> problemIds) {
+//        this.boardId = boardId;
+//        this.title = title;
+//        this.startTime = startTime;
+//        this.endTime = endTime;
+//        this.problemIds = problemIds;
+//    }
 }

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/BoardDetailResponse.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/BoardDetailResponse.java
@@ -16,16 +16,5 @@ public class BoardDetailResponse {
     private String title;
     private LocalDateTime startTime;
     private LocalDateTime endTime;
-    //private List<Long> problemIds;
     private List<ProblemSimpleDto> problems;
-
-
-//    public BoardDetailResponse(Long boardId, String title, LocalDateTime startTime,
-//                               LocalDateTime endTime, List<Long> problemIds) {
-//        this.boardId = boardId;
-//        this.title = title;
-//        this.startTime = startTime;
-//        this.endTime = endTime;
-//        this.problemIds = problemIds;
-//    }
 }

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/ProblemSimpleDto.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/ProblemSimpleDto.java
@@ -1,0 +1,17 @@
+package com.ssafy.BlueStrongMountain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@ToString
+public class ProblemSimpleDto {
+    private Long id;
+    private String title;
+    private Integer difficulty;
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/BoardServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/BoardServiceImpl.java
@@ -7,6 +7,7 @@ import com.ssafy.BlueStrongMountain.exception.BoardNotFoundException;
 import com.ssafy.BlueStrongMountain.repository.BoardProblemRepository;
 import com.ssafy.BlueStrongMountain.repository.BoardRepository;
 import com.ssafy.BlueStrongMountain.repository.BoardUserProgressRepository;
+import com.ssafy.BlueStrongMountain.repository.ProblemRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -20,6 +21,7 @@ import java.util.stream.Collectors;
 public class BoardServiceImpl implements BoardService{
     private final BoardRepository boardRepository;
     private final BoardProblemRepository boardProblemRepository;
+    private final ProblemRepository problemRepository;
 
 
     @Override
@@ -67,13 +69,21 @@ public class BoardServiceImpl implements BoardService{
                 .stream()
                 .map(BoardProblem::getProblemId)
                 .toList();
+        List<ProblemSimpleDto>problems = problemRepository.findByIdList(problemIds)
+                .stream()
+                .map(e -> new ProblemSimpleDto(
+                        e.getId(),
+                        e.getTitle(),
+                        e.getDifficulty()
+                )).toList();
+
         // (검색 조건은 이후 QueryDSL 또는 필터 로직 추가)
         return new BoardDetailResponse(
                 board.getId(),
                 board.getTitle(),
                 board.getStartTime(),
                 board.getEndTime(),
-                problemIds
+                problems
         );
     }
 

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -623,49 +623,14 @@ paths:
                 content: "플로이드-워셜과 최소 컷"
                 startTime: "2025-01-01T10:00:00"
                 endTime: "2025-01-01T12:00:00"
-                problems: [1409, 1508]
+                problems:
+                  - id: 1409
+                    title: "행렬"
+                    difficulty: 12
+                  - id: 1508
+                    title: "레이스"
+                    difficulty: 13
 
-
-
-
-    # patch:
-    #   tags:
-    #    - Board
-    #   summary: Update board
-    #   parameters:
-    #     - in: path
-    #       name: groupId
-    #       required: true
-    #       schema:
-    #         type: integer
-    #     - in: path
-    #       name: boardId
-    #       required: true
-    #       schema:
-    #         type: integer
-    #     - in: query
-    #       name: requesterId
-    #       required: true
-    #       schema:
-    #         type: integer
-    #   requestBody:
-    #     required: true
-    #     content:
-    #       application/json:
-    #         schema:
-    #           $ref: '#/components/schemas/BoardUpdateRequest'
-    #         example:
-    #           title: "그래프 심화 세션(수정)"
-    #           content: "최소 컷 문제 보완 정리"
-    #           startTime: "2025-01-01T11:00:00"
-    #   responses:
-    #     '200':
-    #       description: Updated successfully
-    #       content:
-    #         application/json:
-    #           schema:
-    #             type: string
-    #           example: "updated"
     patch:
       tags:
         - Board
@@ -1291,7 +1256,9 @@ components:
         newOwnerId:
           type: integer
 
-
+      ############################################################
+    # Board DTOs
+    ############################################################
     BoardCreateRequest:
       type: object
       properties:
@@ -1348,6 +1315,19 @@ components:
           example: 5
 
 
+    ProblemSimpleDto:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 1409
+        title:
+          type: string
+          example: "행렬"
+        difficulty:
+          type: integer
+          example: 12
+
 
     BoardDetailResponse:
       type: object
@@ -1371,7 +1351,7 @@ components:
         problems:
           type: array
           items:
-            type: integer
+            $ref: '#/components/schemas/ProblemSimpleDto'
 
     BoardProgressResponse:
       type: object
@@ -1413,7 +1393,9 @@ components:
             type: integer
             format: int64
 
-
+      ############################################################
+    # ProblemFilter DTOs
+    ############################################################
 
     ProblemFilterRequest:
       type: object


### PR DESCRIPTION
이슈번호: https://github.com/cheonggangsan/BlueStrongMountain_backend/issues/45
---
### ✅ 구현 내용

- Board 상세 조회 API(`/groups/{groupId}/boards/{boardId}`) 응답에 문제 요약 정보 추가
- 기존 문제 ID 리스트 방식에서 `ProblemSimpleDto` 기반 구조로 변경
- Board 상세 화면에서 문제 제목/난이도를 한 번에 제공하도록 개선

---

### 📂 변경 모듈

- `dto`
    - `BoardDetailResponse`
    - `ProblemSimpleDto` (신규)
- `service`
    - `BoardServiceImpl`

---

### 🧪 동작 흐름

1. `BoardRepository`를 통해 Board 조회
2. `BoardProblemRepository`에서 board에 연결된 problemId 목록 조회
3. `ProblemRepository.findByIdList()`로 문제 엔티티 일괄 조회
4. `ProblemSimpleDto(id, title, difficulty)`로 변환
5. Board 상세 응답에 문제 요약 리스트 포함하여 반환

---

### 💡 변경 이유

- 프론트엔드에서 문제 제목 및 난이도를 추가 조회해야 하는 구조를 개선
- N+1 쿼리 없이 Board 상세 정보와 문제 요약을 한 번에 제공
- 조회 전용 DTO를 사용해 엔티티 노출 방지 및 응답 명세 명확화

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선사항**
  * 게시판 상세 정보 조회 시 문제 목록에서 제목과 난이도 정보가 추가로 제공됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->