### PR TITLE
[BST-39] 그룹 수정 시 멤버/매니저 변경 로직 및 보드 진행 데이터 정합성 처리

### DIFF
--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/GroupUpdateRequest.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/GroupUpdateRequest.java
@@ -4,12 +4,16 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class GroupUpdateRequest {
 
     private String title;
+    private List<Long> managerIds;
+    private List<Long> memberIds;
     private String visibility;
     private String description;
 }

--- a/src/main/java/com/ssafy/BlueStrongMountain/exception/InvalidGroupCreateException.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/exception/InvalidGroupCreateException.java
@@ -1,7 +1,0 @@
-package com.ssafy.BlueStrongMountain.exception;
-
-public class InvalidGroupCreateException extends RuntimeException {
-    public InvalidGroupCreateException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/com/ssafy/BlueStrongMountain/exception/InvalidGroupException.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/exception/InvalidGroupException.java
@@ -1,0 +1,7 @@
+package com.ssafy.BlueStrongMountain.exception;
+
+public class InvalidGroupException extends RuntimeException {
+    public InvalidGroupException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/exception/InvalidGroupUpdateException.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/exception/InvalidGroupUpdateException.java
@@ -1,7 +1,0 @@
-package com.ssafy.BlueStrongMountain.exception;
-
-public class InvalidGroupUpdateException extends RuntimeException {
-    public InvalidGroupUpdateException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/GroupMemberServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/GroupMemberServiceImpl.java
@@ -1,28 +1,31 @@
 package com.ssafy.BlueStrongMountain.service;
 
+import com.ssafy.BlueStrongMountain.domain.Board;
 import com.ssafy.BlueStrongMountain.domain.GroupRole;
 import com.ssafy.BlueStrongMountain.domain.UserGroup;
 import com.ssafy.BlueStrongMountain.exception.CannotRemoveOwnerException;
 import com.ssafy.BlueStrongMountain.exception.UserNotInGroupException;
+import com.ssafy.BlueStrongMountain.repository.BoardRepository;
+import com.ssafy.BlueStrongMountain.repository.BoardUserProgressRepository;
 import com.ssafy.BlueStrongMountain.repository.UserGroupRepository;
 import com.ssafy.BlueStrongMountain.service.validator.GroupAuthorityService;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
+
+import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@AllArgsConstructor
 public class GroupMemberServiceImpl implements GroupMemberService {
 
     private final UserGroupRepository userGroupRepository;
     private final GroupAuthorityService groupAuthorityService;
 
-    public GroupMemberServiceImpl(
-            final UserGroupRepository userGroupRepository,
-            final GroupAuthorityService groupAuthorityService
-    ) {
-        this.userGroupRepository = userGroupRepository;
-        this.groupAuthorityService = groupAuthorityService;
-    }
+    private final BoardRepository boardRepository;
+    private final BoardUserProgressRepository boardUserProgressRepository;
+
 
     @Override
     public void addManagers(
@@ -134,6 +137,45 @@ public class GroupMemberServiceImpl implements GroupMemberService {
             throw new CannotRemoveOwnerException(requesterId, groupId);
         }
 
+        //본인의 board 문제 풀이 기록 삭제
+        List<Long> toDeleteIds = new ArrayList<>();
+        toDeleteIds.add(requesterId);
+        cleanupBoardUserProgress(groupId, toDeleteIds);
+
         userGroupRepository.deleteByUserIdAndGroupId(requesterId, groupId);
+    }
+
+    private void cleanupBoardUserProgress(
+            Long groupId,
+            List<Long> removedUserIds
+    ){
+        List<Long> boardIds = boardRepository.findByGroupId(groupId)
+                .stream()
+                .map(Board::getId)
+                .toList();
+
+        for(Long boardId : boardIds){
+            for(Long userId : removedUserIds){
+                cleanupUserProgressInBoard(boardId, userId);
+            }
+        }
+
+    }
+    private void cleanupUserProgressInBoard(
+            Long boardId,
+            Long userId
+    ){
+        List<Long> problemIds =
+                boardUserProgressRepository.findProblemIdsByBoardAndUser(
+                        boardId,
+                        userId
+                );
+        if(problemIds.isEmpty()){
+            return;
+        }
+        boardUserProgressRepository.deleteByBoardAndUser(
+                boardId,
+                userId
+        );
     }
 }

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/GroupServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/GroupServiceImpl.java
@@ -196,8 +196,15 @@ public class GroupServiceImpl implements GroupService {
 
 
         //요청 사용자
-        Set<Long> newManagerIds = new HashSet<>(request.getManagerIds());
-        Set<Long> newMemberIds = new HashSet<>(request.getMemberIds());
+        Set<Long> newManagerIds =
+                request.getManagerIds() == null
+                        ? Set.of()
+                        : new HashSet<>(request.getManagerIds());
+
+        Set<Long> newMemberIds =
+                request.getMemberIds() == null
+                        ? Set.of()
+                        : new HashSet<>(request.getMemberIds());
 
         //역할 변경
         for(Long userId : newManagerIds){

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/GroupServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/GroupServiceImpl.java
@@ -6,19 +6,23 @@ import com.ssafy.BlueStrongMountain.dto.GroupDetailDto;
 import com.ssafy.BlueStrongMountain.dto.GroupSummaryDto;
 import com.ssafy.BlueStrongMountain.dto.GroupUpdateRequest;
 import com.ssafy.BlueStrongMountain.exception.GroupNotFoundException;
+import com.ssafy.BlueStrongMountain.repository.BoardRepository;
+import com.ssafy.BlueStrongMountain.repository.BoardUserProgressRepository;
 import com.ssafy.BlueStrongMountain.repository.GroupRepository;
 import com.ssafy.BlueStrongMountain.repository.UserGroupRepository;
 
 import com.ssafy.BlueStrongMountain.service.validator.GroupAuthorityService;
 import com.ssafy.BlueStrongMountain.service.validator.GroupValidator;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import lombok.AllArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
+@AllArgsConstructor
 public class GroupServiceImpl implements GroupService {
 
     private final GroupRepository groupRepository;
@@ -26,18 +30,9 @@ public class GroupServiceImpl implements GroupService {
     private final GroupValidator groupValidator;
     private final GroupAuthorityService groupAuthorityService;
 
+    private final BoardUserProgressRepository boardUserProgressRepository;
+    private final BoardRepository boardRepository;
 
-    public GroupServiceImpl(
-            final GroupRepository groupRepository,
-            final UserGroupRepository userGroupRepository,
-            final GroupValidator groupValidator,
-            final GroupAuthorityService groupAuthorityService
-    ) {
-        this.groupRepository = groupRepository;
-        this.userGroupRepository = userGroupRepository;
-        this.groupValidator = groupValidator;
-        this.groupAuthorityService = groupAuthorityService;
-    }
 
     @Override
     public Long createGroup(
@@ -172,13 +167,100 @@ public class GroupServiceImpl implements GroupService {
             final Long groupId,
             final GroupUpdateRequest request
     ) {
-        groupValidator.validateUpdateRequest(request);
+        groupValidator.validateUpdateRequest(requesterId, request);
         groupAuthorityService.validateOwner(requesterId, groupId);
+
 
         final Group group = groupRepository.findById(groupId)
                 .orElseThrow(() -> new GroupNotFoundException(groupId));
 
         final LocalDateTime now = LocalDateTime.now();
+
+        
+        //기존 유저 조회
+        List<UserGroup> oldGroupUsers =
+                userGroupRepository.findByGroupId(groupId);
+
+        Map<Long, UserGroup> oldUserMap = oldGroupUsers.stream()
+                .collect(Collectors.toMap(UserGroup::getUserId, ug -> ug));
+
+        Set<Long> oldManagerIds = oldGroupUsers.stream()
+                .filter(ug -> ug.getRole() == GroupRole.MANAGER)
+                .map(UserGroup::getUserId)
+                .collect(Collectors.toSet());
+
+        Set<Long> oldMemberIds = oldGroupUsers.stream()
+                .filter(ug -> ug.getRole() == GroupRole.MEMBER)
+                .map(UserGroup::getUserId)
+                .collect(Collectors.toSet());
+
+
+        //요청 사용자
+        Set<Long> newManagerIds = new HashSet<>(request.getManagerIds());
+        Set<Long> newMemberIds = new HashSet<>(request.getMemberIds());
+
+        //역할 변경
+        for(Long userId : newManagerIds){
+            if(oldMemberIds.contains(userId)){
+                UserGroup ug = oldUserMap.get(userId);
+                ug.changeRole(GroupRole.MANAGER);
+                userGroupRepository.updateRole(ug);
+            }
+        }
+
+        for(Long userId : newMemberIds){
+            if(oldManagerIds.contains(userId)){
+                UserGroup ug = oldUserMap.get(userId);
+                ug.changeRole(GroupRole.MEMBER);
+                userGroupRepository.updateRole(ug);
+            }
+        }
+
+
+        //신규 추가
+        for(Long userId : newManagerIds){
+            if(!oldUserMap.containsKey(userId)){
+                userGroupRepository.insert(
+                        UserGroup.create(
+                                userId,
+                                groupId,
+                                GroupRole.MANAGER,
+                                now
+                        )
+                );
+            }
+        }
+
+        for(Long userId : newMemberIds){
+            if(!oldUserMap.containsKey(userId)){
+                userGroupRepository.insert(
+                        UserGroup.create(
+                                userId,
+                                groupId,
+                                GroupRole.MEMBER,
+                                now
+                        )
+                );
+            }
+        }
+
+        //기존 삭제
+        Set<Long> newAll = new HashSet<>();
+        newAll.addAll(newManagerIds);
+        newAll.addAll(newMemberIds);
+
+        List<Long> toDeleteIds = oldUserMap.keySet().stream()
+                .filter(userId -> (!newAll.contains(userId)))
+                .filter(userId -> !userId.equals(requesterId))
+                .toList();
+        if(!toDeleteIds.isEmpty()){
+            userGroupRepository.deleteByGroupIdAndUserIdIn(groupId, toDeleteIds);
+        }
+
+        //BoardUserProgress 삭제
+        cleanupBoardUserProgress(groupId, toDeleteIds);
+
+        //그룹 자체 업데이트
         group.update(
                 request.getTitle(),
                 request.getDescription(),
@@ -192,6 +274,41 @@ public class GroupServiceImpl implements GroupService {
 
         groupRepository.save(group);
     }
+
+    private void cleanupBoardUserProgress(
+            Long groupId,
+            List<Long> removedUserIds
+    ){
+        List<Long> boardIds = boardRepository.findByGroupId(groupId)
+                .stream()
+                .map(Board::getId)
+                .toList();
+
+        for(Long boardId : boardIds){
+            for(Long userId : removedUserIds){
+                cleanupUserProgressInBoard(boardId, userId);
+            }
+        }
+
+    }
+    private void cleanupUserProgressInBoard(
+            Long boardId,
+            Long userId
+    ){
+        List<Long> problemIds =
+                boardUserProgressRepository.findProblemIdsByBoardAndUser(
+                        boardId,
+                        userId
+                );
+        if(problemIds.isEmpty()){
+            return;
+        }
+        boardUserProgressRepository.deleteByBoardAndUser(
+                boardId,
+                userId
+        );
+    }
+
 
     @Override
     public void changeOwner(

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/validator/GroupValidator.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/validator/GroupValidator.java
@@ -2,8 +2,7 @@ package com.ssafy.BlueStrongMountain.service.validator;
 
 import com.ssafy.BlueStrongMountain.dto.GroupCreateRequest;
 import com.ssafy.BlueStrongMountain.dto.GroupUpdateRequest;
-import com.ssafy.BlueStrongMountain.exception.InvalidGroupCreateException;
-import com.ssafy.BlueStrongMountain.exception.InvalidGroupUpdateException;
+import com.ssafy.BlueStrongMountain.exception.InvalidGroupException;
 
 import java.util.HashSet;
 import java.util.List;
@@ -15,11 +14,11 @@ public class GroupValidator {
 
     public void validateCreateRequest(final Long ownerId, final GroupCreateRequest request) {
         if (request == null) {
-            throw new InvalidGroupCreateException("Request must not be null.");
+            throw new InvalidGroupException("Request must not be null.");
         }
 
         if (request.getTitle() == null || request.getTitle().isBlank()) {
-            throw new InvalidGroupCreateException("Group title must not be empty.");
+            throw new InvalidGroupException("Group title must not be empty.");
         }
 
         validateDuplicateIds(ownerId, request.getManagerIds(), request.getMemberIds());
@@ -27,10 +26,10 @@ public class GroupValidator {
 
     public void validateUpdateRequest(final Long ownerId, final GroupUpdateRequest request) {
         if (request == null) {
-            throw new InvalidGroupUpdateException("Request must not be null.");
+            throw new InvalidGroupException("Request must not be null.");
         }
         if (request.getTitle() == null || request.getTitle().isBlank()) {
-            throw new InvalidGroupUpdateException("Group title must not be empty.");
+            throw new InvalidGroupException("Group title must not be empty.");
         }
 
         validateDuplicateIds(ownerId, request.getManagerIds(), request.getMemberIds());
@@ -55,7 +54,7 @@ public class GroupValidator {
         if (managerIds != null) {
             for (Long id : managerIds) {
                 if (set.contains(id)) {
-                    throw new InvalidGroupCreateException("Duplicate id in managerIds and memberIds. id=" + id);
+                    throw new InvalidGroupException("Duplicate id in managerIds and memberIds. id=" + id);
                 }
                 set.add(id);
             }
@@ -63,7 +62,7 @@ public class GroupValidator {
         if (memberIds != null) {
             for (Long id : memberIds) {
                 if (set.contains(id)) {
-                    throw new InvalidGroupCreateException("Duplicate id in managerIds and memberIds. id=" + id);
+                    throw new InvalidGroupException("Duplicate id in managerIds and memberIds. id=" + id);
                 }
                 set.add(id);
             }

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/validator/GroupValidator.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/validator/GroupValidator.java
@@ -30,7 +30,7 @@ public class GroupValidator {
             throw new InvalidGroupUpdateException("Request must not be null.");
         }
         if (request.getTitle() == null || request.getTitle().isBlank()) {
-            throw new InvalidGroupCreateException("Group title must not be empty.");
+            throw new InvalidGroupUpdateException("Group title must not be empty.");
         }
 
         validateDuplicateIds(ownerId, request.getManagerIds(), request.getMemberIds());

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/validator/GroupValidator.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/validator/GroupValidator.java
@@ -25,10 +25,15 @@ public class GroupValidator {
         validateDuplicateIds(ownerId, request.getManagerIds(), request.getMemberIds());
     }
 
-    public void validateUpdateRequest(final GroupUpdateRequest request) {
+    public void validateUpdateRequest(final Long ownerId, final GroupUpdateRequest request) {
         if (request == null) {
             throw new InvalidGroupUpdateException("Request must not be null.");
         }
+        if (request.getTitle() == null || request.getTitle().isBlank()) {
+            throw new InvalidGroupCreateException("Group title must not be empty.");
+        }
+
+        validateDuplicateIds(ownerId, request.getManagerIds(), request.getMemberIds());
     }
 
 //    public void validateDuplicateMemberIds(final List<Long> memberIds) {

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -260,8 +260,6 @@ paths:
                 items:
                   $ref: '#/components/schemas/GroupSummaryResponse'
 
-
-
   /api/v1/groups/{groupId}:
     patch:
       tags: [Group]
@@ -1186,6 +1184,14 @@ components:
       properties:
         title:
           type: string
+        managerIds:
+          type: array
+          items:
+            type: integer
+        memberIds:
+          type: array
+          items:
+            type: integer
         visibility:
           type: string
         description:


### PR DESCRIPTION
이슈번호: https://github.com/cheonggangsan/BlueStrongMountain_backend/issues/39
---

## ✅ 구현 내용

### 1. 그룹 수정(Group Update) 로직 고도화

* 기존 멤버/매니저 목록과 요청 값의 **차이를 계산(diff)** 하여 다음 케이스를 명확히 처리하도록 개선

  * 신규 추가된 사용자 → `UserGroup insert`
  * 역할이 변경된 사용자(MEMBER ↔ MANAGER) → `updateRole`
  * 요청에서 제거된 사용자 → `UserGroup delete`
* 그룹 OWNER(requesterId)는 **삭제 대상에서 명시적으로 제외**하여 무결성 보장
* `GroupUpdateRequest` DTO에 `managerIds`, `memberIds`를 명확히 반영하여 Swagger / 요청 구조 정합성 유지

---

### 2. 그룹 멤버 제거 시 BoardUserProgress 정리 로직 추가

* 그룹에서 제거되는 사용자에 대해:

  * 해당 그룹에 속한 **모든 Board 조회**
  * 각 Board에서 사용자별 **BoardUserProgress 삭제**
* `cleanupBoardUserProgress`, `cleanupUserProgressInBoard`를 private 메서드로 분리하여

  * 책임 분리
  * 가독성 및 재사용성 향상
* 실제 삭제할 데이터가 존재하는 경우에만 delete 수행하여 불필요한 쿼리 방지

---

### 3. 그룹 탈퇴(leaveGroup) 로직에도 동일한 정리 정책 적용

* 사용자가 그룹을 자발적으로 탈퇴하는 경우에도

  * 본인이 속한 그룹의 모든 Board에서
  * 본인의 문제 풀이 기록(BoardUserProgress)을 함께 정리하도록 통일
* OWNER 탈퇴 시 예외(`CannotRemoveOwnerException`) 유지

---

### 4. GroupValidator 검증 로직 확장

* 그룹 수정 시에도:

  * 요청 객체 null 여부 검증
  * 제목(title) 유효성 검증
  * managerIds / memberIds 간 중복 및 OWNER 포함 여부 검증
* 생성(Create)과 수정(Update) 간 검증 책임을 명확히 분리

---

## 📂 변경 모듈

* `GroupServiceImpl`

  * 그룹 수정 시 멤버/역할 변경 로직 전면 개선
  * 그룹 멤버 삭제 시 BoardUserProgress 정리 로직 추가
* `GroupMemberServiceImpl`

  * 그룹 탈퇴 시 BoardUserProgress 정리 로직 적용
* `GroupUpdateRequest`

  * managerIds / memberIds 명확화
* `GroupValidator`

  * 그룹 수정 요청에 대한 검증 강화

---

## 🧪 동작 흐름 요약

1. 그룹 수정 요청 수신
2. 요청 유효성 및 OWNER 권한 검증
3. 기존 그룹 멤버 상태 조회
4. 요청과 기존 상태를 비교하여:

   * 역할 변경
   * 신규 추가
   * 제거 대상 선별
5. 제거 대상 사용자에 대해:

   * UserGroup 삭제
   * 해당 그룹의 모든 Board에서 BoardUserProgress 정리
6. 그룹 기본 정보(title, description, visibility) 업데이트

---

## 💡 기타

* 그룹 멤버 변경 시 발생할 수 있는 **데이터 정합성 문제(BoardUserProgress 잔존)** 를 서비스 레벨에서 명시적으로 해결
* GroupService, GroupMemberService에서 동일 로직 반복 사용 추후 수정해야 함


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 그룹 업데이트 시 매니저/멤버 목록을 일괄 반영하고 역할 전환(매니저↔멤버)을 지원하며 요청자(수정자)는 보존

* **Bug Fixes**
  * 사용자가 그룹에서 제거되거나 탈퇴할 때 그룹 관련 보드 진행 데이터 자동 정리 추가

* **Documentation**
  * API 스키마에 managerIds 및 memberIds 필드 추가

* **Validation**
  * 그룹 업데이트 시 제목 필수 검증 추가 및 중복 ID 검증 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->