### PR TITLE
[BST-49] Board 진행률 응답에 사용자 username 포함하도록 개선

### DIFF
--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/BoardUserStatusDto.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/BoardUserStatusDto.java
@@ -11,5 +11,6 @@ import java.util.List;
 @ToString
 public class BoardUserStatusDto {
     private final Long userId;
+    private final String username;
     private List<Long> solvedProblemIds;
 }

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/BoardApplicationServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/BoardApplicationServiceImpl.java
@@ -5,9 +5,11 @@ import com.ssafy.BlueStrongMountain.domain.BoardUserProgress;
 import com.ssafy.BlueStrongMountain.domain.BoardUserStatus;
 import com.ssafy.BlueStrongMountain.dto.*;
 import com.ssafy.BlueStrongMountain.exception.GroupNotFoundException;
+import com.ssafy.BlueStrongMountain.exception.UserNotFoundException;
 import com.ssafy.BlueStrongMountain.repository.BoardProblemRepository;
 import com.ssafy.BlueStrongMountain.repository.BoardUserProgressRepository;
 import com.ssafy.BlueStrongMountain.repository.GroupRepository;
+import com.ssafy.BlueStrongMountain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +27,7 @@ public class BoardApplicationServiceImpl implements BoardApplicationService{
 
     private final BoardProblemRepository boardProblemRepository;
     private final GroupRepository groupRepository;
+    private final UserRepository userRepository;
 
 
     private final BoardUserProgressRepository boardUserProgressRepository;
@@ -87,6 +90,15 @@ public class BoardApplicationServiceImpl implements BoardApplicationService{
                     .add(problemId);
         }
 
+        //username 캐싱
+        Map<Long, String> usernameMap = new HashMap<>();
+        for(Long userId : userSolvedMap.keySet()){
+            String username = userRepository.findById(userId)
+                    .orElseThrow(UserNotFoundException::new)
+                    .getUsername();
+            usernameMap.put(userId, username);
+        }
+
         List<BoardProblemStatusDto> problemStatus =
                 problemSolvedMap.entrySet()
                     .stream()
@@ -95,8 +107,11 @@ public class BoardApplicationServiceImpl implements BoardApplicationService{
         List<BoardUserStatusDto> userStatus =
                 userSolvedMap.entrySet()
                         .stream()
-                        .map(e -> new BoardUserStatusDto(e.getKey(), e.getValue()))
+                        .map(e -> new BoardUserStatusDto(e.getKey(),
+                                usernameMap.get(e.getKey()),
+                                e.getValue()))
                         .toList();
+
 
         return new BoardProgressResponse(
                 boardId,

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -1386,18 +1386,24 @@ components:
             type: integer
             format: int64
 
-
     BoardUserStatusDto:
       type: object
+      required:
+        - userId
+        - username
+        - solvedProblemIds
       properties:
         userId:
           type: integer
           format: int64
+        username:
+          type: string
         solvedProblemIds:
           type: array
           items:
             type: integer
             format: int64
+
 
       ############################################################
     # ProblemFilter DTOs


### PR DESCRIPTION
이슈번호: https://github.com/cheonggangsan/BlueStrongMountain_backend/issues/49
---

## ✅ 구현 내용

* Board 진행률 조회 API에서 **유저별 solved 정보에 username을 함께 반환**하도록 응답 구조를 확장했습니다.
* `BoardUserStatusDto`에 `username` 필드를 추가하여, 프론트에서 별도 사용자 조회 없이 진행 현황을 바로 표시할 수 있도록 개선했습니다.
* BoardUserProgress 조회 결과를 기반으로, **userId 기준으로 username을 캐싱**하여 중복 조회를 방지했습니다.

---

## 📂 변경 모듈

* `BoardApplicationServiceImpl`

  * `getBoardProgress()` 로직 수정
  * userId → username 매핑을 위한 캐싱 로직 추가
* `BoardUserStatusDto`

  * `username` 필드 추가

---

## 🧪 동작 흐름

1. boardId 기준으로 `BoardUserProgress` 목록 조회
2. `SOLVED` 상태인 데이터만 필터링
3. 문제 기준 / 유저 기준으로 solved 정보 집계
4. **유저 ID 목록을 기준으로 username 조회 및 캐싱**
5. `BoardUserStatusDto(userId, username, solvedProblemIds)` 형태로 응답 생성

---

## 💡 변경 의도 및 기대 효과

* 프론트엔드에서 유저 이름을 표시하기 위해 추가 API 호출이 필요 없도록 개선
* Progress 데이터와 사용자 식별 정보를 하나의 응답으로 제공하여 **API 사용성 향상**
* 현재 `UserRepository` 제약(findById만 존재) 하에서 **중복 조회를 최소화한 안전한 구조**

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 사용자 보드 상태 정보에 사용자명이 추가되었습니다. 이제 보드 진행 상황을 조회할 때 각 사용자의 이름이 함께 반환됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->