### PR TITLE
[BST-51] 그룹 유저 목록 조회 API 추가 및 GroupMemberService 조회 로직 구현

### DIFF
--- a/src/main/java/com/ssafy/BlueStrongMountain/controller/GroupController.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/controller/GroupController.java
@@ -46,6 +46,19 @@ public class GroupController {
     }
 
     /**
+     * 그룹 유저들 조회
+     */
+    @GetMapping("/{groupId}/users")
+    public ResponseEntity<List<GroupUserDto>> getAllUsers(
+            @RequestParam Long requesterId,
+            @PathVariable Long groupId
+    ){
+        //TEST
+        System.out.println("group users controller start!!!!");
+        return ResponseEntity.ok(groupMemberService.getAllUsers(requesterId, groupId));
+    }
+
+    /**
      * 내가 속한 그룹 전체 조회
      */
     @GetMapping

--- a/src/main/java/com/ssafy/BlueStrongMountain/controller/GroupController.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/controller/GroupController.java
@@ -49,11 +49,11 @@ public class GroupController {
      * 그룹 유저들 조회
      */
     @GetMapping("/{groupId}/users")
-    public ResponseEntity<List<GroupUserDto>> getAllUsers(
+    public ResponseEntity<List<GroupUserDto>> getGroupUsers(
             @RequestParam Long requesterId,
             @PathVariable Long groupId
     ){
-        return ResponseEntity.ok(groupMemberService.getAllUsers(requesterId, groupId));
+        return ResponseEntity.ok(groupMemberService.findGroupUsers(requesterId, groupId));
     }
 
     /**

--- a/src/main/java/com/ssafy/BlueStrongMountain/controller/GroupController.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/controller/GroupController.java
@@ -53,8 +53,6 @@ public class GroupController {
             @RequestParam Long requesterId,
             @PathVariable Long groupId
     ){
-        //TEST
-        System.out.println("group users controller start!!!!");
         return ResponseEntity.ok(groupMemberService.getAllUsers(requesterId, groupId));
     }
 

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/GroupUserDto.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/GroupUserDto.java
@@ -1,0 +1,13 @@
+package com.ssafy.BlueStrongMountain.dto;
+
+import com.ssafy.BlueStrongMountain.domain.GroupRole;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class GroupUserDto {
+    private Long userId;
+    private String username;
+    private GroupRole role;
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/GroupMemberService.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/GroupMemberService.java
@@ -1,8 +1,12 @@
 package com.ssafy.BlueStrongMountain.service;
 
+import com.ssafy.BlueStrongMountain.dto.GroupUserDto;
+
 import java.util.List;
 
 public interface GroupMemberService {
+
+    List<GroupUserDto> getAllUsers(Long requesterId, Long groupId);
     void addManagers(Long requesterId, Long groupId, List<Long> userIds);
     void removeManagers(Long requesterId, Long groupId, List<Long> managerIds);
     void addMembers(Long requesterId, Long groupId, List<Long> userIds);

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/GroupMemberService.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/GroupMemberService.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public interface GroupMemberService {
 
-    List<GroupUserDto> getAllUsers(Long requesterId, Long groupId);
+    List<GroupUserDto> findGroupUsers(Long requesterId, Long groupId);
     void addManagers(Long requesterId, Long groupId, List<Long> userIds);
     void removeManagers(Long requesterId, Long groupId, List<Long> managerIds);
     void addMembers(Long requesterId, Long groupId, List<Long> userIds);

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/GroupMemberServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/GroupMemberServiceImpl.java
@@ -37,7 +37,6 @@ public class GroupMemberServiceImpl implements GroupMemberService {
 
     @Override
     public List<GroupUserDto> getAllUsers(Long requesterId, Long groupId) {
-        System.out.println("group users service starts!!!");
         //TODO 검증 로직 추후 추가
         userGroupRepository.findByUserIdAndGroupId(requesterId, groupId)
                 .orElseThrow(() -> new UserNotInGroupException(requesterId, groupId));

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/GroupMemberServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/GroupMemberServiceImpl.java
@@ -36,7 +36,7 @@ public class GroupMemberServiceImpl implements GroupMemberService {
 
 
     @Override
-    public List<GroupUserDto> getAllUsers(Long requesterId, Long groupId) {
+    public List<GroupUserDto> findGroupUsers(Long requesterId, Long groupId) {
         //TODO 검증 로직 추후 추가
         userGroupRepository.findByUserIdAndGroupId(requesterId, groupId)
                 .orElseThrow(() -> new UserNotInGroupException(requesterId, groupId));

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/GroupMemberServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/GroupMemberServiceImpl.java
@@ -2,16 +2,22 @@ package com.ssafy.BlueStrongMountain.service;
 
 import com.ssafy.BlueStrongMountain.domain.Board;
 import com.ssafy.BlueStrongMountain.domain.GroupRole;
+import com.ssafy.BlueStrongMountain.domain.User;
 import com.ssafy.BlueStrongMountain.domain.UserGroup;
+import com.ssafy.BlueStrongMountain.dto.GroupUserDto;
 import com.ssafy.BlueStrongMountain.exception.CannotRemoveOwnerException;
+import com.ssafy.BlueStrongMountain.exception.UserNotFoundException;
 import com.ssafy.BlueStrongMountain.exception.UserNotInGroupException;
 import com.ssafy.BlueStrongMountain.repository.BoardRepository;
 import com.ssafy.BlueStrongMountain.repository.BoardUserProgressRepository;
 import com.ssafy.BlueStrongMountain.repository.UserGroupRepository;
+import com.ssafy.BlueStrongMountain.repository.UserRepository;
 import com.ssafy.BlueStrongMountain.service.validator.GroupAuthorityService;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,6 +32,37 @@ public class GroupMemberServiceImpl implements GroupMemberService {
     private final BoardRepository boardRepository;
     private final BoardUserProgressRepository boardUserProgressRepository;
 
+    private final UserRepository userRepository;
+
+
+    @Override
+    public List<GroupUserDto> getAllUsers(Long requesterId, Long groupId) {
+        System.out.println("group users service starts!!!");
+        //TODO 검증 로직 추후 추가
+        userGroupRepository.findByUserIdAndGroupId(requesterId, groupId)
+                .orElseThrow(() -> new UserNotInGroupException(requesterId, groupId));
+
+        List<UserGroup> userGroups =
+                userGroupRepository.findByGroupId(groupId);
+
+        Map<Long, User> userMap = new HashMap<>();
+
+        //userid로 user 정보와 map에 저장
+        for(UserGroup ug : userGroups){
+            userMap.put(ug.getUserId(),
+                    userRepository.findById(ug.getUserId())
+                            .orElseThrow(UserNotFoundException::new));
+        }
+
+        return userGroups.stream()
+                        .map(ug -> new GroupUserDto(
+                                ug.getUserId(),
+                                userMap.get(ug.getUserId())
+                                                .getUsername(),
+                                ug.getRole()
+                        ))
+                        .toList();
+    }
 
     @Override
     public void addManagers(

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -322,6 +322,39 @@ paths:
         '403':
           description: "그룹 접근 권한 없음"
 
+  /api/v1/groups/{groupId}/users:
+    get:
+      tags:
+        - Group
+      summary: Get all users in a group
+      description: 그룹에 속한 모든 유저 목록을 조회한다.
+      parameters:
+        - in: path
+          name: groupId
+          required: true
+          schema:
+            type: integer
+          description: 그룹 ID
+        - in: query
+          name: requesterId
+          required: true
+          schema:
+            type: integer
+          description: 요청자 사용자 ID
+      responses:
+        '200':
+          description: Group users retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GroupUserDto'
+        '403':
+          description: Permission denied
+        '404':
+          description: User or group not found
+
 
   /api/v1/groups/{groupId}/owner:
     patch:
@@ -1261,6 +1294,22 @@ components:
       properties:
         newOwnerId:
           type: integer
+    GroupUserDto:
+      type: object
+      properties:
+        userId:
+          type: integer
+          example: 1
+        username:
+          type: string
+          example: fermat001
+        role:
+          type: string
+          enum:
+            - OWNER
+            - MANAGER
+            - MEMBER
+          example: MEMBER
 
       ############################################################
     # Board DTOs


### PR DESCRIPTION
이슈번호: https://github.com/cheonggangsan/BlueStrongMountain_backend/issues/51
---

## 구현 내용

* 그룹에 속한 유저 목록을 조회하는 API를 추가했습니다.
* `GroupMemberService`에 그룹 유저 조회 책임을 명확히 분리했습니다.
* 조회 결과 전달을 위한 `GroupUserDto`를 새로 정의했습니다.

---

## 변경 사항 상세

### 1. 그룹 유저 목록 조회 API 추가

* `GET /groups/{groupId}/users`
* 요청 파라미터

  * `groupId` (path): 그룹 ID
  * `requesterId` (query): 요청자 사용자 ID
* 그룹에 속한 유저의 `userId`, `username`, `role` 정보를 반환합니다.


---

### 2. GroupMemberService 조회 메서드 추가

* Service 인터페이스에 `findGroupUsers` 메서드를 추가했습니다.
* Controller와 Service 간 네이밍을 분리하여 역할을 명확히 했습니다.
---

### 3. 그룹 유저 조회 비즈니스 로직 구현

* 요청자가 그룹에 속해 있는지 검증합니다.
* 그룹에 속한 모든 `UserGroup`을 조회합니다.
* `userId` 기준으로 `User` 정보를 조회하여 DTO로 변환합니다.
* 그룹에 존재하지만 유저 정보가 없는 경우 예외를 발생시켜 데이터 정합성을 보장합니다.

---

### 4. GroupUserDto 추가

* 그룹 유저 목록 조회 전용 DTO를 추가했습니다.
* 엔티티 직접 노출을 피하고 응답 책임을 분리했습니다.

---

## 변경 모듈

* `GroupController`
* `GroupMemberService`
* `GroupMemberServiceImpl`
* `GroupUserDto`

---

## 참고 사항

* 현재 구현은 기능 우선으로 작성되었으며,
  이후 성능 개선 시 `UserGroup + User JOIN` 방식으로 리팩토링 가능합니다.
* 권한 검증 로직은 추후 `GroupAuthorityService`를 활용해 세분화할 예정입니다.

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능
* 그룹 멤버 조회 기능: 그룹 내 모든 사용자의 목록을 조회할 수 있습니다. 각 멤버의 사용자명과 역할(Owner, Manager, Member) 정보를 확인할 수 있으며, 그룹에 속한 사용자만 이 기능을 이용할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->