### PR TITLE
[BST-14] 그룹 삭제 기능 구현 및 그룹 관리 로직 정리

### DIFF
--- a/src/main/java/com/ssafy/BlueStrongMountain/controller/GroupController.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/controller/GroupController.java
@@ -64,22 +64,9 @@ public class GroupController {
             @RequestParam Long requesterId,
             @RequestParam(required = false) String name
     ) {
-        //test
-        //List<GroupSummaryDto> tmpDtoList;
-
-
-
         if (name != null && !name.isBlank()) {
-
-            //tmpDtoList = groupService.searchMyGroups(requesterId, name);
-
             return ResponseEntity.ok(groupService.searchMyGroups(requesterId, name));
         }
-
-        //tmpDtoList = groupService.findMyGroups(requesterId);
-//        for(GroupSummaryDto gsd : tmpDtoList){
-//            //System.out.println(gsd.toString());//test
-//        }
 
         return ResponseEntity.ok(groupService.findMyGroups(requesterId));
     }
@@ -96,6 +83,18 @@ public class GroupController {
         groupService.updateGroup(requesterId, groupId, request);
         return ResponseEntity.ok(BaseResponse.ok());
     }
+    /**
+     * 그룹 삭제
+     */
+    @DeleteMapping("/{groupId}")
+    public ResponseEntity<BaseResponse> deleteGroup(
+            @RequestParam Long requesterId,
+            @PathVariable Long groupId
+    ){
+        groupService.deleteGroup(requesterId, groupId);
+        return ResponseEntity.ok(BaseResponse.ok());
+    }
+
 
     /**
      * 그룹 소유권 이전

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/GroupService.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/GroupService.java
@@ -13,4 +13,5 @@ public interface GroupService {
     List<GroupSummaryDto> searchMyGroups(Long requesterId, String name);
     void updateGroup(Long requesterId, Long groupId, GroupUpdateRequest request);
     void changeOwner(Long requesterId, Long groupId, Long newOwnerId);
+    void deleteGroup(Long requesterId, Long groupId);
 }

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/GroupServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/GroupServiceImpl.java
@@ -18,8 +18,8 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import lombok.AllArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @AllArgsConstructor
@@ -125,13 +125,6 @@ public class GroupServiceImpl implements GroupService {
             result.add(GroupSummaryDto.from(group, memberCount));
         }
 
-//        //test
-//        System.out.println("group size in findMyGroups = " + groups.size());
-//        for(Group group : groups){
-//            final int memberCount = userGroupRepository.countByGroupId(group.getId());
-//            System.out.println("group id : " +group.getId() + " memberCount = " + memberCount);
-//        }
-//        //test
 
         result.sort(Comparator.comparing(GroupSummaryDto::getUpdatedAt).reversed());
 
@@ -275,12 +268,59 @@ public class GroupServiceImpl implements GroupService {
                 now
         );
 
-//        //test
-//        System.out.println("update user!!!!! test");
-//        System.out.println(group.toString());
-
         groupRepository.save(group);
     }
+
+
+    @Override
+    public void changeOwner(
+            final Long requesterId,
+            final Long groupId,
+            final Long newOwnerId
+    ) {
+        groupAuthorityService.validateOwnerTransferable(requesterId, groupId, newOwnerId);
+
+        final Group findGroup = groupRepository.findById(groupId)
+                .orElseThrow(() -> new GroupNotFoundException(groupId));
+
+        final LocalDateTime now = LocalDateTime.now();
+        findGroup.changeOwner(newOwnerId, now);
+        groupRepository.save(findGroup);
+
+
+        final UserGroup oldOwner = userGroupRepository.findByUserIdAndGroupId(requesterId, groupId)
+                .orElseThrow(() -> new GroupNotFoundException(groupId));
+        oldOwner.changeRole(GroupRole.MEMBER);
+
+        userGroupRepository.updateRole(oldOwner);
+
+        final UserGroup newOwner = userGroupRepository.findByUserIdAndGroupId(newOwnerId, groupId)
+                .orElseThrow(() -> new GroupNotFoundException(groupId));
+        newOwner.changeRole(GroupRole.OWNER);
+
+        userGroupRepository.updateRole(newOwner);
+    }
+
+    @Override
+    @Transactional
+    public void deleteGroup(Long requesterId, Long groupId) {
+        //owner 검증
+        groupAuthorityService.validateOwner(requesterId, groupId);
+
+        List<Long> deleteUserIds =
+                userGroupRepository.findByGroupId(groupId).stream()
+                        .map(UserGroup::getUserId)
+                        .toList();
+
+        cleanupBoardUserProgress(groupId, deleteUserIds);
+
+        //TODO n+1 문제 있음
+        for(Long userId : deleteUserIds){
+            userGroupRepository.deleteByUserIdAndGroupId(userId, groupId);
+        }
+        groupRepository.deleteById(groupId);
+    }
+
 
     private void cleanupBoardUserProgress(
             Long groupId,
@@ -314,49 +354,5 @@ public class GroupServiceImpl implements GroupService {
                 boardId,
                 userId
         );
-    }
-
-
-    @Override
-    public void changeOwner(
-            final Long requesterId,
-            final Long groupId,
-            final Long newOwnerId
-    ) {
-        groupAuthorityService.validateOwnerTransferable(requesterId, groupId, newOwnerId);
-
-        final Group findGroup = groupRepository.findById(groupId)
-                .orElseThrow(() -> new GroupNotFoundException(groupId));
-
-        final LocalDateTime now = LocalDateTime.now();
-        findGroup.changeOwner(newOwnerId, now);
-        groupRepository.save(findGroup);
-
-//        //test
-//        System.out.println("group update test!!!!!!!!!!!!!!!!");
-//        System.out.println(findGroup.toString());
-//        System.out.println("group update test_end!!!!!!!!!!!!!!!!");
-//        //test
-
-//        //test
-//        System.out.println("before group size" + userGroupRepository.findByUserId(requesterId).size());
-//        groupRepository.save(group);
-//        System.out.println("after group size" + userGroupRepository.findByUserId(requesterId).size());
-//        //test
-
-        final UserGroup oldOwner = userGroupRepository.findByUserIdAndGroupId(requesterId, groupId)
-                .orElseThrow(() -> new GroupNotFoundException(groupId));
-        oldOwner.changeRole(GroupRole.MEMBER);
-
-        userGroupRepository.updateRole(oldOwner);
-
-        final UserGroup newOwner = userGroupRepository.findByUserIdAndGroupId(newOwnerId, groupId)
-                .orElseThrow(() -> new GroupNotFoundException(groupId));
-        newOwner.changeRole(GroupRole.OWNER);
-
-        userGroupRepository.updateRole(newOwner);
-//
-//        userGroupRepository.save(oldOwner);
-//        userGroupRepository.save(newOwner);
     }
 }

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -288,6 +288,57 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BasicResponse'
+    delete:
+      tags:
+        - Group
+      summary: Delete group
+      description: |
+        그룹을 삭제합니다.
+        - 요청자는 해당 그룹의 OWNER여야 합니다.
+        - 그룹에 속한 모든 유저 및 관련 진행 정보가 함께 삭제됩니다.
+      parameters:
+        - in: path
+          name: groupId
+          required: true
+          schema:
+            type: integer
+            format: int64
+          description: 삭제할 그룹 ID
+        - in: query
+          name: requesterId
+          required: true
+          schema:
+            type: integer
+            format: int64
+          description: 그룹 삭제를 요청한 사용자 ID (OWNER)
+      responses:
+        '200':
+          description: Group deleted successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BaseResponse'
+              example:
+                success: true
+                message: "OK"
+        '403':
+          description: Forbidden - requester is not group owner
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BaseResponse'
+              example:
+                success: false
+                message: "Not authorized to delete this group"
+        '404':
+          description: Group not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BaseResponse'
+              example:
+                success: false
+                message: "Group not found"
 
   /api/v1/groups/{groupId}/detail:
     get:


### PR DESCRIPTION
이슈번호: https://github.com/cheonggangsan/BlueStrongMountain_backend/issues/14
---


## ✅ 구현 내용

### 1. 그룹 삭제 기능 추가

* 그룹 OWNER만 그룹을 삭제할 수 있도록 권한 검증 로직을 적용
* 그룹 삭제 시 다음 데이터들을 함께 정리하도록 구현

  * 그룹에 속한 모든 유저의 `UserGroup` 관계
  * 그룹 내 게시판의 사용자 진행 정보(`BoardUserProgress`)
* 삭제 로직 전체를 하나의 트랜잭션으로 처리하여 데이터 정합성 보장

---

### 2. 그룹 관리 서비스 인터페이스 확장

* `GroupService`에 그룹 삭제 기능을 명시적으로 노출

  * `deleteGroup(Long requesterId, Long groupId)` 메서드 추가
* 기존 그룹 수정, 소유권 이전 API와 역할 분리 유지

---

### 3. GroupServiceImpl 로직 정리 및 개선

* 그룹 삭제 시 처리 흐름:

  1. 요청자 OWNER 권한 검증
  2. 그룹에 속한 사용자 ID 목록 조회
  3. 해당 그룹의 게시판 사용자 진행 정보 정리
  4. 그룹-유저 매핑(UserGroup) 삭제
  5. 그룹 엔티티 삭제
* 삭제 과정에서 중간 실패 시 전체 롤백되도록 트랜잭션 적용

---

### 4. 불필요한 디버그 코드 제거

* 그룹 조회 및 수정 과정에서 사용되던 테스트용 `System.out.println` 코드 제거
* 서비스 로직 가독성 및 유지보수성 개선

---

## 📂 변경된 주요 모듈

* `GroupController`

  * 그룹 삭제 API (`DELETE /api/v1/groups/{groupId}`) 추가
* `GroupService`

  * 그룹 삭제 메서드 선언 추가
* `GroupServiceImpl`

  * 그룹 삭제 비즈니스 로직 구현
  * 그룹 관리 관련 테스트/디버그 코드 정리

---

## 🧪 동작 흐름 요약

1. 클라이언트가 그룹 삭제 요청
2. 요청자의 OWNER 권한 검증
3. 그룹에 속한 모든 사용자 및 진행 정보 정리
4. 그룹-유저 관계 삭제
5. 그룹 엔티티 삭제
6. 정상 완료 시 공통 성공 응답 반환

---

## 💡 참고 사항

* 현재 그룹 삭제 시 `UserGroup` 삭제 과정에서 N+1 DELETE가 발생함

  * 기능 동작에는 문제 없으나, 추후 bulk delete 방식으로 개선 예정
* 향후 JWT 인증 도입 시 `requesterId` 파라미터 제거 가능하도록 확장 고려

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 그룹 삭제: 소유자가 그룹 및 관련 멤버, 진행 데이터를 삭제할 수 있습니다.
* 그룹 소유권 이전: 현재 소유자가 다른 멤버에게 소유권을 양도할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->