### PR TITLE
[BST-55] fix: 그룹 매니저 이상 권한 검증 로직 추가 및 예외 분리

### DIFF
--- a/src/main/java/com/ssafy/BlueStrongMountain/exception/ManagerPermissionRequiredException.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/exception/ManagerPermissionRequiredException.java
@@ -1,0 +1,7 @@
+package com.ssafy.BlueStrongMountain.exception;
+
+public class ManagerPermissionRequiredException extends RuntimeException{
+    public ManagerPermissionRequiredException(){
+        super("Manager or higher permission is required.");
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/BoardApplicationServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/BoardApplicationServiceImpl.java
@@ -10,6 +10,7 @@ import com.ssafy.BlueStrongMountain.repository.BoardProblemRepository;
 import com.ssafy.BlueStrongMountain.repository.BoardUserProgressRepository;
 import com.ssafy.BlueStrongMountain.repository.GroupRepository;
 import com.ssafy.BlueStrongMountain.repository.UserRepository;
+import com.ssafy.BlueStrongMountain.service.validator.GroupAuthorityService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,6 +30,8 @@ public class BoardApplicationServiceImpl implements BoardApplicationService{
     private final GroupRepository groupRepository;
     private final UserRepository userRepository;
 
+    private final GroupAuthorityService groupAuthorityService;
+
 
     private final BoardUserProgressRepository boardUserProgressRepository;
 
@@ -43,6 +46,7 @@ public class BoardApplicationServiceImpl implements BoardApplicationService{
 
         //groupId 검증
         validateGroupExists(groupId);
+        groupAuthorityService.validateManager(requesterId, groupId);
 
 
         if(req.getEndTime() != null && LocalDateTime.now().isAfter(req.getEndTime())){
@@ -132,6 +136,7 @@ public class BoardApplicationServiceImpl implements BoardApplicationService{
             BoardUpdateRequest req) {
         //groupId 검증
         validateGroupExists(groupId);
+        groupAuthorityService.validateManager(requesterId, groupId);
 
         BoardDetailResponse findBoard = boardService.getBoard(groupId, boardId);
 
@@ -178,6 +183,7 @@ public class BoardApplicationServiceImpl implements BoardApplicationService{
             Long boardId) {
         //groupId 검증
         validateGroupExists(groupId);
+        groupAuthorityService.validateManager(requesterId, groupId);
 
         boardUserProgressService.deleteByBoard(boardId);
 

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/validator/GroupAuthorityServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/validator/GroupAuthorityServiceImpl.java
@@ -3,6 +3,7 @@ package com.ssafy.BlueStrongMountain.service.validator;
 import com.ssafy.BlueStrongMountain.domain.GroupRole;
 import com.ssafy.BlueStrongMountain.domain.UserGroup;
 import com.ssafy.BlueStrongMountain.exception.CannotTransferOwnershipException;
+import com.ssafy.BlueStrongMountain.exception.ManagerPermissionRequiredException;
 import com.ssafy.BlueStrongMountain.exception.OwnerPermissionRequiredException;
 import com.ssafy.BlueStrongMountain.exception.UserNotInGroupException;
 import com.ssafy.BlueStrongMountain.repository.UserGroupRepository;
@@ -31,7 +32,7 @@ public class GroupAuthorityServiceImpl implements GroupAuthorityService {
         final UserGroup userGroup = getUserGroupOrThrow(userId, groupId);
 
         if (userGroup.getRole() == GroupRole.MEMBER) {
-            throw new OwnerPermissionRequiredException();
+            throw new ManagerPermissionRequiredException();
         }
     }
 


### PR DESCRIPTION
이슈번호: https://github.com/cheonggangsan/BlueStrongMountain_backend/issues/55
---

## 구현 내용

* 그룹 내 **MANAGER 이상 권한(MANAGER, OWNER)** 을 요구하는 전용 예외를 추가하였다.
* 기존에 OWNER 전용으로 오해될 수 있던 권한 예외를 역할 수준에 맞게 분리하였다.
* 게시판(Board) 생성·수정·삭제 시 그룹 내 권한 검증을 일관되게 적용하였다.

---

## 주요 변경 사항

### 1. 권한 예외 클래스 추가

* `ManagerPermissionRequiredException` 신규 추가

  * 의미: 그룹 내에서 **MANAGER 이상 권한이 필요한 경우**
  * MEMBER 역할 접근 시 명확한 예외 메시지 제공

### 2. GroupAuthorityService 권한 검증 로직 개선

* `validateManager(userId, groupId)` 로직에서

  * MEMBER 역할일 경우 `ManagerPermissionRequiredException` 발생
* 권한 요구 수준(Owner 전용 vs Manager 이상)을 예외 이름으로 명확히 구분

### 3. BoardApplicationService 권한 검증 강화

* 아래 Board 관련 작업에서 **매니저 이상 권한 검증**을 공통 적용

  * 게시판 생성
  * 게시판 수정
  * 게시판 삭제
* 그룹 존재 검증 이후 권한 검증을 수행하도록 흐름 정리

---

## 변경 의도 및 효과

* 기존 `OwnerPermissionRequiredException` 사용으로 인한

  * “OWNER만 가능한 기능인가?”라는 혼동 제거
* 도메인 역할 구조(MEMBER / MANAGER / OWNER)를

  * 예외 이름과 서비스 로직에 정확히 반영
* 추후 권한 정책 확장 시

  * 역할별 검증 로직과 예외를 명확히 분리할 수 있는 구조 확보

---

## 영향 범위

* Group 권한 검증 로직
* Board 생성·수정·삭제 API 동작
* 권한 부족 시 반환되는 예외 타입 및 메시지



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 게시판 생성, 수정, 삭제 작업 시 그룹 관리자 권한 검증이 추가되었습니다.
  * 권한 부족 시 명확한 오류 메시지가 표시됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->