### PR TITLE
[BST-60] refactoring: BoardUserProgress 초기화 시 UserSolution 동기화 제거 및 스케줄러 책임 분리

### DIFF
--- a/src/main/java/com/ssafy/BlueStrongMountain/service/BoardUserProgressServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/BoardUserProgressServiceImpl.java
@@ -18,7 +18,6 @@ public class BoardUserProgressServiceImpl implements BoardUserProgressService {
 
     private final BoardUserProgressRepository progressRepository;
     private final UserGroupRepository userGroupRepository;
-    private final UserSolutionRepository userSolutionRepository;
 
     /* ===============================
      * 초기화
@@ -53,10 +52,10 @@ public class BoardUserProgressServiceImpl implements BoardUserProgressService {
                 BoardUserProgress progress =
                         new BoardUserProgress(boardId, userId, problemId);
 
-                // user_solution에 있으면 solved 처리
-                userSolutionRepository
-                        .findByUserAndProblem(userId, problemId)
-                        .ifPresent(solution -> progress.markSolved());
+//                // user_solution에 있으면 solved 처리
+//                userSolutionRepository
+//                        .findByUserAndProblem(userId, problemId)
+//                        .ifPresent(solution -> progress.markSolved());
 
                 progressRepository.save(progress);
             }


### PR DESCRIPTION
이슈번호: https://github.com/cheonggangsan/BlueStrongMountain_backend/issues/60
---


## ✅ 변경 배경

기존에는 `BoardUserProgressService.initializeBoardProgress()` 내부에서
`UserSolution`을 직접 조회하여 **즉시 SOLVED 상태를 반영**하는 로직이 포함되어 있었다.

하지만 이 방식은 다음과 같은 문제를 가진다.

* Board 생성/수정 시점마다 동기화 책임이 분산됨
* 동일한 UserSolution 동기화 로직이 여러 위치에 중복될 가능성
* 외부 동기화(solved.ac) → 내부 상태 보정 책임 경계가 불분명함

이에 따라 **UserSolution 최신화 및 solved 상태 판단 책임을 스케줄러로 일원화**하고,
`initializeBoardProgress`는 **순수 초기화 역할만 수행하도록 구조를 정리**하였다.

---

## 🔧 변경 내용 요약

### 1. `initializeBoardProgress`에서 UserSolution 기반 동기화 로직 제거

* BoardUserProgress 초기화 시

  * 더 이상 UserSolution을 탐색하지 않음
  * 모든 문제를 기본 상태(PENDING)로만 생성
* 해당 메서드는 **“보드-유저-문제 관계 초기화” 책임만 유지**

---

### 2. UserSolution 동기화 책임을 스케줄러로 분리

* solved.ac 기반 UserSolution 최신화는

  * `SolvedAcScheduler`에서 주기적으로 수행
* BoardUserProgress의 SOLVED 반영은

  * 이미 최신화된 UserSolution 테이블을 기준으로
  * create / update 시점의 `syncBoardUserProgress`에서 처리

---

## 🧠 설계 의도

```text
[Scheduler]
→ solved.ac 동기화
→ UserSolution 최신화

[Board 생성/수정]
→ BoardUserProgress 구조 초기화
→ UserSolution 기준 상태 보정(syncBoardUserProgress)

[initializeBoardProgress]
→ 관계 생성만 담당 (동기화 로직 제거)
```

* solved 상태 판단의 기준을 **항상 UserSolution으로 통일**
* 초기화 로직과 동기화 로직의 책임을 명확히 분리
* 중복 로직 제거 및 향후 확장성 확보

---

## 🚀 기대 효과

* Board 초기화 로직 단순화
* 동기화 책임의 단일화로 설계 명확성 향상
* 불필요한 UserSolution 조회 제거
* 향후 동기화 정책 변경 시 스케줄러만 수정하면 되도록 구조 정리

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 진행 상황 초기화 시 자동 완료 상태 표시 기능이 비활성화되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->