### PR TITLE
[BST-64] feat: 그룹 요약 응답에 사용자 역할(groupRole) 포함

### DIFF
--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/GroupSummaryDto.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/GroupSummaryDto.java
@@ -1,6 +1,7 @@
 package com.ssafy.BlueStrongMountain.dto;
 
 import com.ssafy.BlueStrongMountain.domain.Group;
+import com.ssafy.BlueStrongMountain.domain.GroupRole;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -13,6 +14,7 @@ public class GroupSummaryDto {
     private Long ownerId;
     private String visibility;
     private int memberCount;
+    private GroupRole groupRole;
     private String createdAt;
     private String updatedAt;
 
@@ -22,6 +24,7 @@ public class GroupSummaryDto {
             final Long ownerId,
             final String visibility,
             final int memberCount,
+            final GroupRole groupRole,
             final String createdAt,
             final String updatedAt
     ) {
@@ -30,12 +33,14 @@ public class GroupSummaryDto {
         this.ownerId = ownerId;
         this.visibility = visibility;
         this.memberCount = memberCount;
+        this.groupRole = groupRole;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }
 
     public static GroupSummaryDto from(
             final Group group,
+            final GroupRole groupRole,
             final int memberCount
     ) {
         return new GroupSummaryDto(
@@ -44,6 +49,7 @@ public class GroupSummaryDto {
                 group.getOwnerId(),
                 group.getVisibility().name(),
                 memberCount,
+                groupRole,
                 group.getCreatedAt().toString(),
                 group.getUpdatedAt().toString()
         );

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/GroupServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/GroupServiceImpl.java
@@ -15,6 +15,7 @@ import com.ssafy.BlueStrongMountain.service.validator.GroupAuthorityService;
 import com.ssafy.BlueStrongMountain.service.validator.GroupValidator;
 import java.time.LocalDateTime;
 import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import lombok.AllArgsConstructor;
@@ -109,7 +110,9 @@ public class GroupServiceImpl implements GroupService {
 
     @Override
     public List<GroupSummaryDto> findMyGroups(final Long requesterId) {
-        final List<Long> myGroupIds = userGroupRepository.findByUserId(requesterId).stream()
+        //TODO db 접근 비효율성
+        List<UserGroup> myGroups = userGroupRepository.findByUserId(requesterId);
+        final List<Long> myGroupIds = myGroups.stream()
                 .map(UserGroup::getGroupId)
                 .toList();
 
@@ -119,10 +122,23 @@ public class GroupServiceImpl implements GroupService {
 
         final List<Group> groups = groupRepository.findByIds(myGroupIds);
 
+        Map<Long, Group> groupMap = groups.stream()
+                .collect(Collectors.toMap(Group::getId, Function.identity()));
+
+        Map<Long, GroupRole> myGroupRoleMap = myGroups.stream()
+                .collect(Collectors.toMap(UserGroup::getGroupId, UserGroup::getRole));
+
         final List<GroupSummaryDto> result = new ArrayList<>();
-        for (Group group : groups) {
-            final int memberCount = userGroupRepository.countByGroupId(group.getId());
-            result.add(GroupSummaryDto.from(group, memberCount));
+
+        for(Long groupId : myGroupIds){
+            final int memberCount = userGroupRepository.countByGroupId(groupId);
+            GroupRole myGroupRole = myGroupRoleMap.get(groupId);
+
+            result.add(GroupSummaryDto.from(
+                    groupMap.get(groupId),
+                    myGroupRole,
+                    memberCount)
+            );
         }
 
 

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -1365,13 +1365,34 @@ components:
     GroupSummaryResponse:
       type: object
       properties:
-        id: { type: integer }
-        title: { type: string }
-        ownerId: { type: integer }
-        visibility: { type: string }
-        memberCount: { type: integer }
-        createdAt: { type: string }
-        updatedAt: { type: string }
+        id:
+          type: integer
+          format: int64
+        title:
+          type: string
+        ownerId:
+          type: integer
+          format: int64
+        visibility:
+          type: string
+          description: Group visibility
+          example: PUBLIC
+        memberCount:
+          type: integer
+          example: 5
+        groupRole:
+          type: string
+          description: Role of requester in the group
+          enum:
+            - OWNER
+            - MANAGER
+            - MEMBER
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
 
     GroupDetailDto:
       type: object


### PR DESCRIPTION
이슈번호: https://github.com/cheonggangsan/BlueStrongMountain_backend/issues/64
---


### ✅ 구현 내용

* `GroupSummaryDto`에 **요청자 기준 그룹 역할(`groupRole`) 필드 추가**
* 그룹 요약 응답에 사용자의 권한 정보(OWNER / MANAGER / MEMBER) 포함
* `GroupSummaryResponse` Swagger 스키마를 실제 응답 DTO와 **동기화**

  * `groupRole` 필드 추가
  * enum 값 명시
  * `createdAt`, `updatedAt`에 `date-time` 포맷 명시

---

### 📂 변경 모듈

* `com.ssafy.BlueStrongMountain.dto.GroupSummaryDto`
* Swagger OpenAPI YAML

  * `GroupSummaryResponse`

---

### 🧪 동작 흐름

1. 요청자가 속한 그룹 목록 조회
2. 각 그룹에 대해

   * 그룹 기본 정보
   * 요청자의 그룹 내 역할(`groupRole`)
   * 그룹 멤버 수
     를 포함한 요약 DTO 생성
3. 그룹 목록을 `updatedAt` 기준으로 내림차순 정렬 후 반환

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  - 그룹 조회 시 사용자의 그룹 내 역할(소유자/관리자/멤버) 정보 표시

* **문서화**
  - API 스키마 정의 확대 및 그룹 역할 필드 추가로 더 명확한 문서화 제공

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->