### PR TITLE
[BST-66] fix: userStatus 반환 시 user는 해당 그룹의 모든 유저를 보내는 방식으로 수정

### DIFF
--- a/src/main/java/com/ssafy/BlueStrongMountain/service/BoardApplicationServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/BoardApplicationServiceImpl.java
@@ -88,11 +88,17 @@ public class BoardApplicationServiceImpl implements BoardApplicationService{
         Map<Long, List<Long>> problemSolvedMap = new HashMap<>();
         Map<Long, List<Long>> userSolvedMap = new HashMap<>();
 
-        for(BoardUserProgress progress : progresses){
-            if(progress.getStatus() != BoardUserStatus.SOLVED) continue;
+        Set<Long> allUserIds = new HashSet<>();
 
+        for(BoardUserProgress progress : progresses){
             Long problemId = progress.getProblemId();
             Long userId = progress.getUserId();
+            allUserIds.add(userId);
+
+            if(progress.getStatus() != BoardUserStatus.SOLVED){
+                continue;
+            }
+
 
             problemSolvedMap
                     .computeIfAbsent(problemId, k -> new ArrayList<>())
@@ -104,7 +110,8 @@ public class BoardApplicationServiceImpl implements BoardApplicationService{
 
         //username 캐싱
         Map<Long, String> usernameMap = new HashMap<>();
-        for(Long userId : userSolvedMap.keySet()){
+        //for(Long userId : userSolvedMap.keySet()){
+        for(Long userId : allUserIds){
             String username = userRepository.findById(userId)
                     .orElseThrow(UserNotFoundException::new)
                     .getUsername();
@@ -116,13 +123,21 @@ public class BoardApplicationServiceImpl implements BoardApplicationService{
                     .stream()
                     .map(e -> new BoardProblemStatusDto(e.getKey(), e.getValue()))
                     .toList();
-        List<BoardUserStatusDto> userStatus =
-                userSolvedMap.entrySet()
-                        .stream()
-                        .map(e -> new BoardUserStatusDto(e.getKey(),
-                                usernameMap.get(e.getKey()),
-                                e.getValue()))
-                        .toList();
+
+        List<BoardUserStatusDto> userStatus = new ArrayList<>();
+        for(Long userId : allUserIds){
+
+            String username = usernameMap.get(userId);
+            List<Long> solvedProblemIds = new ArrayList<>();
+            if(userSolvedMap.get(userId) != null && !userSolvedMap.get(userId).isEmpty()){
+                solvedProblemIds = userSolvedMap.get(userId);
+            }
+            userStatus.add(new BoardUserStatusDto(
+                    userId,
+                    username,
+                    solvedProblemIds
+            ));
+        }
 
 
         return new BoardProgressResponse(


### PR DESCRIPTION
이슈번호: https://github.com/cheonggangsan/BlueStrongMountain_backend/issues/66
---
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 그룹 보드 화면에서 문제를 풀지 않은 사용자를 포함하여 모든 사용자의 상태 정보가 정확하게 표시되도록 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->