### PR TITLE
[BST-70] 비밀번호 재설정 메일 전송 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -736,4 +736,7 @@ gradle-app.setting
 # Java heap dump
 *.hprof
 
+### local
+application-local.properties
+
 # End of https://www.toptal.com/developers/gitignore/api/eclipse,intellij,intellij+all,intellij+iml,windows,macos,linux,gradle,maven,visualstudiocode,vue,vuejs,python,jupyternotebooks,flask,git,redis

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
 
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/com/ssafy/BlueStrongMountain/controller/AuthController.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/controller/AuthController.java
@@ -23,11 +23,6 @@ public class AuthController {
 
     @PostMapping("/register")
     public ResponseEntity<RegisterResponse> register(@RequestBody RegisterRequest req){
-
-        //test
-        System.out.println("!!!!!!!!!register user");
-        System.out.println(req.toString());
-
         return ResponseEntity.ok(authService.register(req));
     }
 
@@ -54,6 +49,14 @@ public class AuthController {
             @RequestBody @Valid LogoutRequest req
     ){
         authService.logout(req);
+        return ResponseEntity.ok(BaseResponse.ok());
+    }
+
+    @PostMapping("/password/reset")
+    public ResponseEntity<BaseResponse> resetPassword(
+            @RequestBody @Valid PasswordResetRequest req
+    ){
+        authService.resetPasswordByEmail(req.getEmail());
         return ResponseEntity.ok(BaseResponse.ok());
     }
 }

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/PasswordResetRequest.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/PasswordResetRequest.java
@@ -1,0 +1,12 @@
+package com.ssafy.BlueStrongMountain.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class PasswordResetRequest {
+    @Email
+    @NotBlank
+    private String email;
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/AuthService.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/AuthService.java
@@ -7,4 +7,5 @@ public interface AuthService {
     public LoginResponse login(LoginRequest req);
     public UsernameDuplicateResponse checkUsername(String username);
     void logout(LogoutRequest req);
+    void resetPasswordByEmail(String email);
 }

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/AuthServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/AuthServiceImpl.java
@@ -10,12 +10,16 @@ import lombok.AllArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.security.SecureRandom;
+
 @Service
 @AllArgsConstructor
 public class AuthServiceImpl implements AuthService{
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
+
+    private final EmailService emailService;
 
     @Override
     public RegisterResponse register(RegisterRequest req) {
@@ -89,5 +93,34 @@ public class AuthServiceImpl implements AuthService{
         user = user.withRefreshToken(null);
 
         userRepository.save(user);
+    }
+
+    @Override
+    public void resetPasswordByEmail(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(UserNotFoundException::new);
+
+        String newPassword = randomPasswordGenerator(PASS_LENGTH);
+        String encoded = passwordEncoder.encode(newPassword);
+
+        User updatedUser = user.withPassword(encoded);
+
+        userRepository.save(updatedUser);
+
+        emailService.sendTemporaryPassword(updatedUser.getEmail(), newPassword);
+    }
+
+    private final Integer PASS_LENGTH = 8;
+    private final String CHAR_POOL =
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    private String randomPasswordGenerator(int length){
+        final SecureRandom random = new SecureRandom();
+        StringBuilder sb =  new StringBuilder();
+
+        for(int i =0 ; i<length; i++){
+            int idx = random.nextInt(CHAR_POOL.length());
+            sb.append(CHAR_POOL.charAt(idx));
+        }
+        return sb.toString();
     }
 }

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/AuthServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/AuthServiceImpl.java
@@ -100,17 +100,16 @@ public class AuthServiceImpl implements AuthService{
     @Override
     @Transactional
     public void resetPasswordByEmail(String email) {
-        User user = userRepository.findByEmail(email)
-                .orElseThrow(UserNotFoundException::new);
+        userRepository.findByEmail(email).ifPresent(user -> {
+            String newPassword = randomPasswordGenerator(PASS_LENGTH);
+            String encoded = passwordEncoder.encode(newPassword);
 
-        String newPassword = randomPasswordGenerator(PASS_LENGTH);
-        String encoded = passwordEncoder.encode(newPassword);
+            User updatedUser = user.withPassword(encoded);
 
-        User updatedUser = user.withPassword(encoded);
+            userRepository.save(updatedUser);
 
-        userRepository.save(updatedUser);
-
-        emailService.sendTemporaryPassword(updatedUser.getEmail(), newPassword);
+            emailService.sendTemporaryPassword(updatedUser.getEmail(), newPassword);
+        });
     }
 
     private final Integer PASS_LENGTH = 8;

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/AuthServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/AuthServiceImpl.java
@@ -9,6 +9,7 @@ import com.ssafy.BlueStrongMountain.repository.UserRepository;
 import lombok.AllArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.security.SecureRandom;
 
@@ -95,7 +96,9 @@ public class AuthServiceImpl implements AuthService{
         userRepository.save(user);
     }
 
+    //TODO 이메일 검증 로직 따로 없음
     @Override
+    @Transactional
     public void resetPasswordByEmail(String email) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(UserNotFoundException::new);

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/EmailService.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/EmailService.java
@@ -1,0 +1,24 @@
+package com.ssafy.BlueStrongMountain.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+    private final JavaMailSender mailSender;
+
+    public void sendTemporaryPassword(String toEmail, String tempPassword){
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(toEmail);
+        message.setSubject("[BlueStrongMountain] 임시 비밀번호 안내");
+        message.setText(
+                "임시 비밀번호가 발급되었습니다.\n\n"
+                        + "임시 비밀번호: " + tempPassword + "\n\n"
+                        + "로그인 후 반드시 비밀번호를 변경해주세요."
+        );
+        mailSender.send(message);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,13 +2,15 @@ spring.application.name=BlueStrongMountain
 
 server.port=8080
 
+spring.profiles.active=local
+
 spring.devtools.restart.enabled=true
 
 #db setting....
 spring.datasource.url=jdbc:mysql://127.0.0.1:3306/bst
-#db username, password ??
-spring.datasource.username=
-spring.datasource.password=
+##application-local? ??
+#spring.datasource.username=
+#spring.datasource.password=
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 #mybatis setting( mapper file , type alias): multi package: list vo packages seperated by ,
@@ -16,4 +18,16 @@ mybatis.type-aliases-package=com.ssafy.BlueStrongMountain.domain
 mybatis.mapper-locations=classpath:mybatis/mapper/*Mapper.xml
 
 #log
-logging.level.com.mvc.mapper=debug
+logging.level.com.ssafy.BlueStrongMountain.repository.mapper=debug
+logging.level.org.springframework.transaction=TRACE
+
+
+#mail
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+##application-local? ??
+#spring.mail.username=
+#spring.mail.password=
+
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -115,6 +115,27 @@ paths:
               schema:
                 $ref: '#/components/schemas/BaseResponse'
 
+  /api/v1/auth/password/reset:
+    post:
+      tags:
+        - Auth
+      summary: Reset password
+      description: |
+        이메일로 임시 비밀번호를 발급합니다.
+        보안상 이메일 존재 여부와 관계없이 성공 응답을 반환할 수 있습니다.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PasswordResetRequest'
+      responses:
+        '200':
+          description: Temporary password sent
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BaseResponse'
 
   ############################################################
   # UserController
@@ -1273,6 +1294,16 @@ components:
         refreshToken:
           type: string
           example: "REFRESH_TOKEN_JWT"
+
+    PasswordResetRequest:
+      type: object
+      required:
+        - email
+      properties:
+        email:
+          type: string
+          format: email
+
 
     ############################################################
     # User DTOs


### PR DESCRIPTION
이슈번호: https://github.com/cheonggangsan/BlueStrongMountain_backend/issues/70
---


## PR 본문

### ✅ 구현 내용

* 이메일 기반 **비밀번호 재설정(임시 비밀번호 발급)** 기능을 추가하였습니다.
* 사용자가 이메일을 입력하면:

  * 서버에서 임의의 8자리 비밀번호를 생성
  * 해당 비밀번호를 암호화하여 DB에 저장
  * 이메일로 임시 비밀번호를 발송
* 보안상 이메일 존재 여부와 관계없이 성공 응답(`200 OK`)을 반환하도록 설계하였습니다.

---

### 📂 변경 모듈

* `AuthController`

  * `POST /api/v1/auth/password/reset` API 추가
* `AuthService`

  * 비밀번호 재설정 메서드 인터페이스 추가
* `AuthServiceImpl`

  * 임시 비밀번호 생성 및 저장 로직 구현
* `EmailService`

  * SMTP 기반 임시 비밀번호 메일 발송 로직 추가
* `PasswordGenerator` (util)

  * `SecureRandom` 기반 랜덤 비밀번호 생성 유틸 추가
* Swagger(OpenAPI)

  * 비밀번호 재설정 API 명세 추가

---

### 🧪 동작 흐름

1. 클라이언트에서 이메일을 포함한 비밀번호 재설정 요청 전송
2. 서버에서 이메일로 사용자 조회
3. 임의의 8자리 임시 비밀번호 생성
4. 임시 비밀번호를 `PasswordEncoder`로 암호화하여 사용자 정보 업데이트
5. JavaMailSender를 통해 임시 비밀번호 이메일 발송
6. 성공 응답 반환

---
# APPLICATION-LOCAL.PROPERTIES 분리 및 민감 정보 관리 #
```
spring.datasource.username=
spring.datasource.password=
spring.mail.username=
spring.mail.password=
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 비밀번호 리셋: 이메일로 임시 비밀번호를 발급받아 초기화할 수 있습니다.
  * 임시 비밀번호 자동 발송: 비밀번호 재설정 시 임시비밀번호가 이메일로 전송됩니다.

* **문서**
  * API 스펙에 비밀번호 리셋 엔드포인트 추가 및 요청 스키마 반영

* **기타**
  * 로컬 프로파일 및 메일 설정 항목 추가, 로컬 환경용 설정 파일 무시 규칙 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->