### PR TITLE
[BST-72] feat: JWT 인증 필터 및 AuthContext 도입으로 요청 단위 인증 구조 선구축

### DIFF
--- a/src/main/java/com/ssafy/BlueStrongMountain/auth/AuthContext.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/auth/AuthContext.java
@@ -1,0 +1,17 @@
+package com.ssafy.BlueStrongMountain.auth;
+
+
+public class AuthContext {
+    private static final ThreadLocal<Long> USER_ID =
+            new ThreadLocal<>();
+    private AuthContext(){}
+    public static void setUserId(Long userId){
+        USER_ID.set(userId);
+    }
+    public static Long getUserId(){
+        return USER_ID.get();
+    }
+    public static void clear(){
+        USER_ID.remove();
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/auth/JwtAuthFilter.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/auth/JwtAuthFilter.java
@@ -1,0 +1,72 @@
+package com.ssafy.BlueStrongMountain.auth;
+
+import com.ssafy.BlueStrongMountain.exception.InvalidTokenException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+    private final JwtProvider jwtProvider;
+
+    //filter 미적용 api uri
+    private static final List<String> PUBLIC_PATHS = List.of(
+            //"/api/v1/auth/refresh",
+            "/api/v1/auth/password/reset",
+            "/api/v1/auth/existHandle",
+            "/api/v1/auth/duplicate/username",
+            "/api/v1/auth/register",
+            "/api/v1/auth/login"
+    );
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain)
+            throws ServletException, IOException {
+        try{
+            String token = resolveToken(request);
+
+            if(token != null){
+                if(!jwtProvider.validateToken(token)){
+                    response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid or expired token");
+                    return;
+                }
+
+                Long userId = jwtProvider.getUserIdFromToken(token);
+                AuthContext.setUserId(userId);
+            }
+
+            //swagger 테스트시 주석처리
+            else{
+                if(!isPublicPath(request)){
+                    response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid or expired token");
+                    return;
+                }
+            }
+
+            filterChain.doFilter(request, response);
+        }finally {
+            AuthContext.clear();
+        }
+    }
+    private String resolveToken(HttpServletRequest req){
+        String bearer = req.getHeader("Authorization");
+        if(bearer == null || !bearer.startsWith("Bearer")){
+            return null;
+        }
+        return bearer.substring(7);
+    }
+
+    private boolean isPublicPath(HttpServletRequest req){
+        String uri = req.getRequestURI();
+        return  PUBLIC_PATHS.stream().anyMatch(uri::startsWith);
+    }
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/auth/JwtProvider.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/auth/JwtProvider.java
@@ -57,12 +57,12 @@ public class JwtProvider {
                 .compact();
     }
 
-    public boolean validateToken(String refreshToken){
+    public boolean validateToken(String token){
         try{
             Jwts.parserBuilder()
                     .setSigningKey(key)
                     .build()
-                    .parseClaimsJws(refreshToken);
+                    .parseClaimsJws(token);
             return true;
         }catch (Exception e){
             return false;

--- a/src/main/java/com/ssafy/BlueStrongMountain/config/FilterConfig.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/config/FilterConfig.java
@@ -1,0 +1,26 @@
+package com.ssafy.BlueStrongMountain.config;
+
+import com.ssafy.BlueStrongMountain.auth.JwtAuthFilter;
+import com.ssafy.BlueStrongMountain.auth.JwtProvider;
+import jakarta.servlet.Filter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class FilterConfig {
+    private final JwtProvider jwtProvider;
+
+    @Bean
+    public FilterRegistrationBean<Filter> jwtAuthFilter(){
+        FilterRegistrationBean<Filter> registrationBean
+                = new FilterRegistrationBean<>();
+        registrationBean.setFilter(new JwtAuthFilter(jwtProvider));
+        registrationBean.setOrder(1);
+        registrationBean.addUrlPatterns("/*");
+
+        return registrationBean;
+    }
+}


### PR DESCRIPTION
이슈번호: https://github.com/cheonggangsan/BlueStrongMountain_backend/issues/72
---
## ✅ 변경 내용 요약

이번 PR에서는 **JWT 기반 인증 구조를 사전 구축**하기 위해

`JwtAuthFilter`와 `AuthContext(ThreadLocal)`를 도입하였습니다.

기존 Controller / Service 로직은 변경하지 않고,

**Filter 레벨에서 accessToken 검증 및 인증 강제 여부 판단**만 수행하도록 설계하였습니다.

---

## 📂 변경 파일

- `auth/AuthContext.java`
- `auth/JwtAuthFilter.java`
- `auth/JwtProvider.java`
- `config/FilterConfig.java`

---
## 🧩 주요 변경 사항

### 1. AuthContext (ThreadLocal) 추가

- 요청 단위 사용자 식별을 위해 `ThreadLocal<Long>` 기반 `AuthContext` 도입
- Filter에서 추출한 `userId`를 전 계층에서 접근 가능하도록 구성
- 요청 종료 시 `clear()` 호출로 ThreadLocal 누수 방지

```java
AuthContext.setUserId(userId);
AuthContext.getUserId();

```

---

### 2. JwtAuthFilter 신규 구현

- `OncePerRequestFilter` 기반 JWT 인증 필터 추가
- `Authorization: Bearer <accessToken>` 헤더 기반 accessToken 검증
- 토큰 유효 시:
    - userId 추출 후 `AuthContext`에 저장
- 토큰 무효/만료 시:
    - `401 Unauthorized` 직접 응답
- 토큰 미존재 시:
    - public API는 통과
    - protected API는 `401 Unauthorized` 반환

### Public API 목록

```java
/api/v1/auth/login
/api/v1/auth/register
/api/v1/auth/password/reset
/api/v1/auth/existHandle
/api/v1/auth/duplicate/username

```

---

### 3. JwtProvider 메서드 명확화

- `validateToken(String token)`으로 파라미터 명 수정
- accessToken / refreshToken 공용 검증 메서드로 사용 가능하도록 정리

---

### 4. FilterConfig 추가

- Spring Security 없이 `FilterRegistrationBean`을 통해 `JwtAuthFilter` 등록
- 모든 요청(`/*`)에 대해 필터 적용
- 기존 MVC 구조에 영향 없이 인증 인프라만 선 구축

---
## 💡 설계 의도 및 고려사항

- **requesterId 기반 기존 로직은 유지**
    - 인증 구조를 점진적으로 전환하기 위한 설계
- 인증(Authentication)과 권한(Authorization) 책임 분리
    - Filter: 인증
    - Service: 권한 판단
- Filter 레벨에서 예외를 throw하지 않고 HTTP status 직접 응답
    - Filter는 DispatcherServlet 이전 단계이기 때문

---

## 🔮 향후 확장 방향

- `/auth/refresh` API 추가를 통한 accessToken 재발급
- AuthContext 기반으로 requesterId 제거
- 필요 시 Spring Security(SecurityContext)로 자연스러운 마이그레이션 가능

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* JWT 토큰 기반 인증이 모든 요청에 적용되도록 강화되었습니다.
* 공개 API 경로는 인증 없이 접근 가능합니다.
* 인증되지 않은 요청에 대해 401 응답이 반환됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->