### PR TITLE
[BST-74] feat: 비밀번호 일치 여부 확인 API 추가

### DIFF
--- a/src/main/java/com/ssafy/BlueStrongMountain/controller/AuthController.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/controller/AuthController.java
@@ -5,7 +5,6 @@ import com.ssafy.BlueStrongMountain.service.AuthService;
 import com.ssafy.BlueStrongMountain.service.SolvedAcSyncService;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -24,6 +23,13 @@ public class AuthController {
     @PostMapping("/register")
     public ResponseEntity<RegisterResponse> register(@RequestBody RegisterRequest req){
         return ResponseEntity.ok(authService.register(req));
+    }
+
+    @PostMapping("/password/verify")
+    public ResponseEntity<Boolean> verifyPassword(
+            @RequestBody PasswordVerifyRequest request
+    ) {
+        return ResponseEntity.ok(authService.confirmPassword(request));
     }
 
     @GetMapping("/duplicate/username")

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/PasswordVerifyRequest.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/PasswordVerifyRequest.java
@@ -1,0 +1,11 @@
+package com.ssafy.BlueStrongMountain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PasswordVerifyRequest {
+    private Long userId;
+    private String password;
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/AuthService.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/AuthService.java
@@ -3,9 +3,10 @@ package com.ssafy.BlueStrongMountain.service;
 import com.ssafy.BlueStrongMountain.dto.*;
 
 public interface AuthService {
-    public RegisterResponse register(RegisterRequest req);
-    public LoginResponse login(LoginRequest req);
-    public UsernameDuplicateResponse checkUsername(String username);
+    RegisterResponse register(RegisterRequest req);
+    LoginResponse login(LoginRequest req);
+    boolean confirmPassword(PasswordVerifyRequest req);
+    UsernameDuplicateResponse checkUsername(String username);
     void logout(LogoutRequest req);
     void resetPasswordByEmail(String email);
 }

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/AuthServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/AuthServiceImpl.java
@@ -72,6 +72,13 @@ public class AuthServiceImpl implements AuthService{
     }
 
     @Override
+    public boolean confirmPassword(PasswordVerifyRequest req) {
+        User foundUser = userRepository.findById(req.getUserId())
+                .orElseThrow(AuthenticationFailedException::new);
+        return passwordEncoder.matches(req.getPassword(), foundUser.getPassword());
+    }
+
+    @Override
     public UsernameDuplicateResponse checkUsername(String username) {
 
         boolean isSameName = userRepository.findByUsername(username).isPresent();

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -49,6 +49,48 @@ paths:
               schema:
                 $ref: '#/components/schemas/RegisterResponse'
 
+  /api/v1/auth/password/verify:
+    post:
+      tags:
+        - Auth
+      summary: 비밀번호 일치 여부 검증
+      description: |
+        전달된 userId에 해당하는 사용자의 비밀번호가
+        입력된 password와 일치하는지 검증합니다.
+  
+        회원 탈퇴, 비밀번호 변경 등
+        민감한 작업 전 검증 용도로 사용됩니다.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - userId
+                - password
+              properties:
+                userId:
+                  type: integer
+                  format: int64
+                  example: 1
+                password:
+                  type: string
+                  format: password
+                  example: "myPassword123!"
+      responses:
+        200:
+          description: 비밀번호 검증 결과
+          content:
+            application/json:
+              schema:
+                type: boolean
+                example: true
+        401:
+          description: 인증 실패 (존재하지 않는 사용자 또는 인증 실패)
+
+
+
   /api/v1/auth/duplicate/username:
     get:
       tags: [Auth]


### PR DESCRIPTION
이슈번호: https://github.com/cheonggangsan/BlueStrongMountain_backend/issues/74
---

## 추후 개선 방향

* JWT 인증 구조 완성 시:

  * `userId` 제거
  * 토큰 기반 사용자 식별로 리팩터링 예정
* 필요 시:

  * 비밀번호 검증 실패 횟수 제한
  * 민감 API 전용 재인증 플로우로 확장 가능

---

## 변경 파일

* `AuthController`
* `PasswordVerifyRequest`
* `AuthService`
* `AuthServiceImpl`

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **암호 검증**: 사용자 ID와 암호를 통해 암호를 검증하는 새로운 API 엔드포인트가 추가되었습니다. 검증 결과는 성공 여부로 반환됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->