### PR TITLE
[BST-80] 그룹 인원 추가 시 BoardUserProgress 동기화 로직 추가

### DIFF
--- a/src/main/java/com/ssafy/BlueStrongMountain/service/GroupServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/GroupServiceImpl.java
@@ -385,9 +385,10 @@ public class GroupServiceImpl implements GroupService {
             List<Long> newUserIds
     ){
         List<Board> boards = boardRepository.findByGroupId(groupId);
+        LocalDateTime curTime = LocalDateTime.now();
 
         for(Board board : boards){
-            if(LocalDateTime.now().isAfter(board.getEndTime()))
+            if(curTime.isAfter(board.getEndTime()))
                 continue;
             for(Long userId : newUserIds){
                 addUserProgressInBoard(board.getId(), userId);
@@ -405,17 +406,12 @@ public class GroupServiceImpl implements GroupService {
                         .map(BoardProblem::getProblemId)
                         .toList();
 
+        List<BoardUserProgress> boardUserProgresses = new ArrayList<>();
         for(Long problemId : problemIds){
-            if(boardUserProgressRepository
-                    .find(boardId, userId, problemId).isPresent())
-                continue;
-            boardUserProgressRepository.save(
-                    new BoardUserProgress(
-                            boardId,
-                            userId,
-                            problemId
-                    )
+            boardUserProgresses.add(
+                    new BoardUserProgress(boardId, userId, problemId)
             );
         }
+        boardUserProgressRepository.saveAll(boardUserProgresses);
     }
 }

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/GroupServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/GroupServiceImpl.java
@@ -6,10 +6,7 @@ import com.ssafy.BlueStrongMountain.dto.GroupDetailDto;
 import com.ssafy.BlueStrongMountain.dto.GroupSummaryDto;
 import com.ssafy.BlueStrongMountain.dto.GroupUpdateRequest;
 import com.ssafy.BlueStrongMountain.exception.GroupNotFoundException;
-import com.ssafy.BlueStrongMountain.repository.BoardRepository;
-import com.ssafy.BlueStrongMountain.repository.BoardUserProgressRepository;
-import com.ssafy.BlueStrongMountain.repository.GroupRepository;
-import com.ssafy.BlueStrongMountain.repository.UserGroupRepository;
+import com.ssafy.BlueStrongMountain.repository.*;
 
 import com.ssafy.BlueStrongMountain.service.validator.GroupAuthorityService;
 import com.ssafy.BlueStrongMountain.service.validator.GroupValidator;
@@ -33,6 +30,7 @@ public class GroupServiceImpl implements GroupService {
 
     private final BoardUserProgressRepository boardUserProgressRepository;
     private final BoardRepository boardRepository;
+    private final BoardProblemRepository boardProblemRepository;
 
 
     @Override
@@ -260,11 +258,22 @@ public class GroupServiceImpl implements GroupService {
             }
         }
 
+        //TODO boardUserProgress에 업데이트
+        //TODO 신규 인원 배열 설정
         //기존 삭제
         Set<Long> newAll = new HashSet<>();
         newAll.addAll(newManagerIds);
         newAll.addAll(newMemberIds);
 
+        List<Long> newUserIds = newAll.stream()
+                .filter(userId -> (!oldUserMap.containsKey(userId)))
+                .toList();
+
+
+        addBoardUserProgress(groupId, newUserIds);
+
+
+        //기존 삭제
         List<Long> toDeleteIds = oldUserMap.keySet().stream()
                 .filter(userId -> (!newAll.contains(userId)))
                 .filter(userId -> !userId.equals(requesterId))
@@ -370,5 +379,45 @@ public class GroupServiceImpl implements GroupService {
                 boardId,
                 userId
         );
+    }
+
+
+    private void addBoardUserProgress(
+            Long groupId,
+            List<Long> newUserIds
+    ){
+        List<Board> boards = boardRepository.findByGroupId(groupId);
+
+        for(Board board : boards){
+            if(LocalDateTime.now().isAfter(board.getEndTime()))
+                continue;
+            for(Long userId : newUserIds){
+                addUserProgressInBoard(board.getId(), userId);
+            }
+        }
+    }
+
+    private void addUserProgressInBoard(
+            Long boardId,
+            Long userId
+    ){
+        List<Long> problemIds =
+                boardProblemRepository.findByBoardId(boardId)
+                        .stream()
+                        .map(BoardProblem::getProblemId)
+                        .toList();
+
+        for(Long problemId : problemIds){
+            if(boardUserProgressRepository
+                    .find(boardId, userId, problemId).isPresent())
+                continue;
+            boardUserProgressRepository.save(
+                    new BoardUserProgress(
+                            boardId,
+                            userId,
+                            problemId
+                    )
+            );
+        }
     }
 }

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/GroupServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/GroupServiceImpl.java
@@ -108,7 +108,7 @@ public class GroupServiceImpl implements GroupService {
 
     @Override
     public List<GroupSummaryDto> findMyGroups(final Long requesterId) {
-        //TODO db 접근 비효율성
+        //FIXME db 접근 비효율성
         List<UserGroup> myGroups = userGroupRepository.findByUserId(requesterId);
         final List<Long> myGroupIds = myGroups.stream()
                 .map(UserGroup::getGroupId)
@@ -258,8 +258,6 @@ public class GroupServiceImpl implements GroupService {
             }
         }
 
-        //TODO boardUserProgress에 업데이트
-        //TODO 신규 인원 배열 설정
         //기존 삭제
         Set<Long> newAll = new HashSet<>();
         newAll.addAll(newManagerIds);
@@ -339,7 +337,7 @@ public class GroupServiceImpl implements GroupService {
 
         cleanupBoardUserProgress(groupId, deleteUserIds);
 
-        //TODO n+1 문제 있음
+        //FIXME n+1 문제 있음
         for(Long userId : deleteUserIds){
             userGroupRepository.deleteByUserIdAndGroupId(userId, groupId);
         }


### PR DESCRIPTION
이슈번호: https://github.com/cheonggangsan/BlueStrongMountain_backend/issues/80
---

## ✅ 구현 내용

* 그룹 유저 변경 시 **추가 / 삭제 유저를 diff 기반으로 추론**하도록 로직 개선
* 새로 추가된 유저에 대해 **진행 중인 Board의 BoardUserProgress 자동 생성**
* 그룹에서 제거된 유저에 대해 **BoardUserProgress 정리(cleanup) 처리**
* 기존 로직 대비 **의도 명확성 및 유지보수성 개선**

---

## 📂 변경 모듈

* `GroupApplicationServiceImpl`

  * 그룹 유저 변경 처리 로직
  * `addBoardUserProgress(...)`
  * `addUserProgressInBoard(...)`
  * `cleanupBoardUserProgress(...)` (기존 사용)

---

## 🧠 동작 흐름

### 1️⃣ 신규 유저 (new - old)

* 요청으로 들어온 **최종 유저 집합(newAll)** 과
* 기존 그룹 유저 맵(oldUserMap)을 비교하여
* **기존에 없던 유저만 신규 유저로 판별**

---

### 2️⃣ 신규 유저 BoardUserProgress 생성

```java
addBoardUserProgress(groupId, newUserIds);
```

* 해당 그룹의 모든 Board 조회
* **이미 종료된 Board는 제외**
* Board에 포함된 모든 Problem에 대해

  * `(boardId, userId, problemId)` 기준 중복 체크
  * 없을 경우 `BoardUserProgress` 생성

👉 신규 유저가 **현재 진행 중인 Board에 즉시 참여 가능**하도록 보장

---


## 💡 설계 의도 및 장점

* **diff 기반 동기화(new - old / old - new)** 로직 적용
* 추가 / 삭제 로직이 **완전히 대칭 구조**
* Board 상태(종료 여부)를 고려하여 **불필요한 데이터 생성 방지**
* 기존 N+1 이슈 인지 및 TODO/FIXME 명시 (후속 개선 여지 확보)

---

## 🧪 테스트 포인트

* 기존 유저 유지 시 BoardUserProgress 중복 생성되지 않는지
* 신규 유저 추가 시:

  * 진행 중 Board에 대해서만 Progress 생성되는지
* 유저 삭제 시:

  * BoardUserProgress 정상적으로 정리되는지
* requesterId가 삭제 대상에 포함되지 않는지




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 그룹에 새로 추가된 멤버의 보드 진행 상황이 자동으로 동기화됩니다. 새 멤버가 가입되면 현재 진행 중인(종료되지 않은) 보드의 문제들에 대한 개인 진행 데이터가 자동 생성됩니다.
* **기타**
  * 그룹 수정 시 새로 추가된 멤버에 대한 진행 동기화가 즉시 적용됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->