### PR TITLE
[BST-82] 그룹 기반 문제 추천 로직 추가

### DIFF
--- a/src/main/java/com/ssafy/BlueStrongMountain/controller/ProblemFilterController.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/controller/ProblemFilterController.java
@@ -70,7 +70,7 @@ public class ProblemFilterController {
 //        }
 
 
-        List<ProblemDto> filtered = filterService.applyFilters(base, request);
+        List<ProblemDto> filtered = filterService.applyFilters(groupId, base, request);
 
 //
         System.out.println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");//test

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/ProblemFilterRequest.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/ProblemFilterRequest.java
@@ -31,6 +31,43 @@ public class ProblemFilterRequest {
 
     }
 
+    public ProblemFilterRequest withTags(List<String> tags) {
+        return new ProblemFilterRequest(
+                this.mode,
+                this.problemIds,
+                this.difficultyFrom,
+                this.difficultyTo,
+                tags,
+                this.minSolvers,
+                this.unsolved,
+                this.option
+        );
+    }
+    public ProblemFilterRequest withMinSolvers(int minSolvers) {
+        return new ProblemFilterRequest(
+                this.mode,
+                this.problemIds,
+                this.difficultyFrom,
+                this.difficultyTo,
+                this.tags,
+                minSolvers,
+                this.unsolved,
+                this.option
+        );
+    }
+    public ProblemFilterRequest withDifficulty(int difficultyFrom, int difficultyTo) {
+        return new ProblemFilterRequest(
+                this.mode,
+                this.problemIds,
+                difficultyFrom,
+                difficultyTo,
+                this.tags,
+                this.minSolvers,
+                this.unsolved,
+                this.option
+        );
+    }
+
     @Override
     public String toString() {
         return "ProblemFilterRequest{" +

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/ProblemFilterRequest.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/ProblemFilterRequest.java
@@ -22,7 +22,7 @@ public class ProblemFilterRequest {
                                 Integer option) {
         this.mode = (mode != null && !mode.isEmpty()) ? mode : "normal";  // 기본값 처리
         this.problemIds = problemIds != null ? problemIds : Collections.emptyList();
-        this.difficultyFrom = difficultyFrom != null ? difficultyFrom : 0;
+        this.difficultyFrom = difficultyFrom != null ? difficultyFrom : 1;
         this.difficultyTo = difficultyTo != null ? difficultyTo : 35;
         this.tags = tags != null ? tags : Collections.emptyList();
         this.minSolvers = minSolvers != null ? minSolvers : 0;

--- a/src/main/java/com/ssafy/BlueStrongMountain/dto/ProblemFilterRequest.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/dto/ProblemFilterRequest.java
@@ -50,7 +50,7 @@ public class ProblemFilterRequest {
                 this.difficultyFrom,
                 this.difficultyTo,
                 this.tags,
-                minSolvers,
+                Math.max(minSolvers, 0),
                 this.unsolved,
                 this.option
         );

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/GroupAnalysisService.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/GroupAnalysisService.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 public interface GroupAnalysisService {
 
-    Map<String, Long> getGroupTags(Long groupId);
+
+    Map<String, Long> countSolvedProblemTagsByGroupId(Long groupId);
     List<ProblemDto> fetchProblemsByGroupId(Long groupId);
 }

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/GroupAnalysisService.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/GroupAnalysisService.java
@@ -1,0 +1,12 @@
+package com.ssafy.BlueStrongMountain.service;
+
+import com.ssafy.BlueStrongMountain.dto.ProblemDto;
+
+import java.util.List;
+import java.util.Map;
+
+public interface GroupAnalysisService {
+
+    Map<String, Long> getGroupTags(Long groupId);
+    List<ProblemDto> fetchProblemsByGroupId(Long groupId);
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/GroupAnalysisService.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/GroupAnalysisService.java
@@ -6,8 +6,8 @@ import java.util.List;
 import java.util.Map;
 
 public interface GroupAnalysisService {
-
-
+    List<String> recommendTagsByGroup(Long groupId);
+    double calculateAverageDifficultyByGroupId(Long groupId);
     Map<String, Long> countSolvedProblemTagsByGroupId(Long groupId);
     List<ProblemDto> fetchProblemsByGroupId(Long groupId);
 }

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/GroupAnalysisServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/GroupAnalysisServiceImpl.java
@@ -16,7 +16,7 @@ public class GroupAnalysisServiceImpl implements GroupAnalysisService{
     private final BoardRepository boardRepository;
 
     @Override
-    public Map<String, Long> getGroupTags(Long groupId) {
+    public Map<String, Long> countSolvedProblemTagsByGroupId(Long groupId) {
         Map<String, Long> tagCountByCategory = new HashMap<>();
 
         List<ProblemDto> problems = fetchProblemsByGroupId(groupId);

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/GroupAnalysisServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/GroupAnalysisServiceImpl.java
@@ -77,7 +77,7 @@ public class GroupAnalysisServiceImpl implements GroupAnalysisService{
         tagCountByCategory.put("String", 0L);
         tagCountByCategory.put("Math", 0L);
         tagCountByCategory.put("Search", 0L);
-        tagCountByCategory.put("BruteForce", 0L);
+        tagCountByCategory.put("Bruteforce", 0L);
         tagCountByCategory.put("Implementation", 0L);
 
 
@@ -93,13 +93,6 @@ public class GroupAnalysisServiceImpl implements GroupAnalysisService{
                 );
             }
         }
-
-        //TODO erase this
-        for(String key : tagCountByCategory.keySet()){
-            System.out.println(key + " " + tagCountByCategory.get(key));
-        }
-
-
 
         return tagCountByCategory;
     }

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/GroupAnalysisServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/GroupAnalysisServiceImpl.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -16,8 +17,69 @@ public class GroupAnalysisServiceImpl implements GroupAnalysisService{
     private final BoardRepository boardRepository;
 
     @Override
+    public List<String> recommendTagsByGroup(Long groupId){
+        // 1. 카테고리별 풀이 수 집계
+        Map<String, Long> tagCountByCategory =
+                countSolvedProblemTagsByGroupId(groupId);
+
+        // 2. softmax 확률로 카테고리 하나 선택
+        String selectedCategory =
+                selectCategoryBySoftmax(tagCountByCategory);
+
+        // 3. 선택된 카테고리에 해당하는 태그 목록 반환
+        return mapCategoryToTag(selectedCategory);
+    }
+
+    private String selectCategoryBySoftmax(Map<String, Long> tagCountByCategory){
+        double beta = 0.5;
+        Map<String, Double> weightMap = new HashMap<>();
+        double totalWeight = 0.0;
+
+        for(Map.Entry<String, Long> entry : tagCountByCategory.entrySet()){
+            long count = entry.getValue();
+            double weight = Math.exp(-beta * count);
+            weightMap.put(entry.getKey(), weight);
+            totalWeight += weight;
+        }
+
+        double r = Math.random() * totalWeight;
+        double acc = 0.0;
+
+        for(Map.Entry<String, Double> entry : weightMap.entrySet()){
+            acc += entry.getValue();
+            if(r <= acc){
+                return entry.getKey();
+            }
+        }
+        //이론상 도달하진 않음
+        return weightMap.keySet().iterator().next();
+    }
+
+    @Override
+    public double calculateAverageDifficultyByGroupId(Long groupId) {
+        List<ProblemDto> problems = fetchProblemsByGroupId(groupId);
+
+        return problems.stream()
+                .map(ProblemDto::getDifficulty)
+                .filter(Objects::nonNull)
+                .mapToInt(Integer::intValue)
+                .average()
+                .orElse(0.0);
+    }
+
+    @Override
     public Map<String, Long> countSolvedProblemTagsByGroupId(Long groupId) {
         Map<String, Long> tagCountByCategory = new HashMap<>();
+        tagCountByCategory.put("DP", 0L);
+        tagCountByCategory.put("Graph", 0L);
+        tagCountByCategory.put("DataStructure", 0L);
+        tagCountByCategory.put("Greedy", 0L);
+        tagCountByCategory.put("String", 0L);
+        tagCountByCategory.put("Math", 0L);
+        tagCountByCategory.put("Search", 0L);
+        tagCountByCategory.put("BruteForce", 0L);
+        tagCountByCategory.put("Implementation", 0L);
+
 
         List<ProblemDto> problems = fetchProblemsByGroupId(groupId);
 
@@ -42,6 +104,7 @@ public class GroupAnalysisServiceImpl implements GroupAnalysisService{
         return tagCountByCategory;
     }
 
+
     @Override
     public List<ProblemDto> fetchProblemsByGroupId(Long groupId) {
         return problemFetchService.fetchReviewProblems(groupId);
@@ -53,6 +116,12 @@ public class GroupAnalysisServiceImpl implements GroupAnalysisService{
         }
 
         return TAG_TO_CATEGORY.getOrDefault(tag, "Other");
+    }
+    private List<String> mapCategoryToTag(String category) {
+        if (category == null || category.isBlank()) {
+            return List.of();
+        }
+        return CATEGORY_TO_TAGS.getOrDefault(category, List.of());
     }
     private static final Map<String, String> TAG_TO_CATEGORY = Map.ofEntries(
             // DP
@@ -73,11 +142,11 @@ public class GroupAnalysisServiceImpl implements GroupAnalysisService{
             Map.entry("floyd_warshall", "Graph"),
             Map.entry("topological_sorting", "Graph"),
             Map.entry("minimum_spanning_tree", "Graph"),
-            Map.entry("union_find", "Graph/DSU"),
-            Map.entry("flow", "Graph/Flow"),
-            Map.entry("bipartite_matching", "Graph/Matching"),
-            Map.entry("scc", "Graph/SCC"),
-            Map.entry("2_sat", "Graph/2-SAT"),
+            Map.entry("union_find", "Graph"),
+            Map.entry("flow", "Graph"),
+            Map.entry("bipartite_matching", "Graph"),
+            Map.entry("scc", "Graph"),
+            Map.entry("2_sat", "Graph"),
 
             // Data Structure
             Map.entry("data_structures", "DataStructure"),
@@ -85,15 +154,19 @@ public class GroupAnalysisServiceImpl implements GroupAnalysisService{
             Map.entry("queue", "DataStructure"),
             Map.entry("deque", "DataStructure"),
             Map.entry("priority_queue", "DataStructure"),
-            Map.entry("segtree", "DataStructure/SegmentTree"),
-            Map.entry("fenwick", "DataStructure/Fenwick"),
-            Map.entry("sparse_table", "DataStructure/SparseTable"),
-            Map.entry("trie", "DataStructure/Trie"),
-            Map.entry("hashing", "DataStructure/Hashing"),
+            Map.entry("segtree", "DataStructure"),
+            Map.entry("fenwick", "DataStructure"),
+            Map.entry("sparse_table", "DataStructure"),
+            Map.entry("trie", "DataStructure"),
+            Map.entry("hashing", "DataStructure"),
 
-            // Greedy / Implementation / String
+            // Greedy
             Map.entry("greedy", "Greedy"),
+
+            // Implementation
             Map.entry("implementation", "Implementation"),
+
+            // String
             Map.entry("string", "String"),
             Map.entry("kmp", "String"),
             Map.entry("suffix_array", "String"),
@@ -103,16 +176,27 @@ public class GroupAnalysisServiceImpl implements GroupAnalysisService{
             Map.entry("math", "Math"),
             Map.entry("number_theory", "Math"),
             Map.entry("combinatorics", "Math"),
-            Map.entry("geometry", "Geometry"),
+            Map.entry("geometry", "Math"),
 
-            // Search / Paradigms
+            // Search
             Map.entry("binary_search", "Search"),
             Map.entry("parametric_search", "Search"),
-            Map.entry("divide_and_conquer", "Divide&Conquer"),
-            Map.entry("two_pointer", "TwoPointers"),
-            Map.entry("sliding_window", "SlidingWindow"),
-            Map.entry("bruteforcing", "Bruteforce"),
-            Map.entry("backtracking", "Backtracking"),
-            Map.entry("meet_in_the_middle", "MeetInTheMiddle")
+            Map.entry("divide_and_conquer", "Search"),
+            Map.entry("two_pointer", "Search"),
+            Map.entry("sliding_window", "Search"),
+            Map.entry("meet_in_the_middle", "Search"),
+            Map.entry("backtracking", "Search"),
+
+
+            // Bruteforce
+            Map.entry("bruteforcing", "Bruteforce")
     );
+
+    // 역매핑: category -> tags
+    private static final Map<String, List<String>> CATEGORY_TO_TAGS =
+            TAG_TO_CATEGORY.entrySet().stream()
+                    .collect(Collectors.groupingBy(
+                            Map.Entry::getValue,
+                            Collectors.mapping(Map.Entry::getKey, Collectors.toUnmodifiableList())
+                    ));
 }

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/GroupAnalysisServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/GroupAnalysisServiceImpl.java
@@ -1,0 +1,118 @@
+package com.ssafy.BlueStrongMountain.service;
+
+import com.ssafy.BlueStrongMountain.dto.ProblemDto;
+import com.ssafy.BlueStrongMountain.repository.BoardProblemRepository;
+import com.ssafy.BlueStrongMountain.repository.BoardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class GroupAnalysisServiceImpl implements GroupAnalysisService{
+    private final BoardProblemRepository boardProblemRepository;
+    private final ProblemFetchService problemFetchService;
+    private final BoardRepository boardRepository;
+
+    @Override
+    public Map<String, Long> getGroupTags(Long groupId) {
+        Map<String, Long> tagCountByCategory = new HashMap<>();
+
+        List<ProblemDto> problems = fetchProblemsByGroupId(groupId);
+
+        for(ProblemDto problem : problems){
+            List<String> tags = problem.getTags();
+            for(String tag : tags){
+                String categorizedTag = mapTagToCategory(tag);
+                tagCountByCategory.put(
+                        categorizedTag,
+                        tagCountByCategory.getOrDefault(categorizedTag, 0L) + 1
+                );
+            }
+        }
+
+        //TODO erase this
+        for(String key : tagCountByCategory.keySet()){
+            System.out.println(key + " " + tagCountByCategory.get(key));
+        }
+
+
+
+        return tagCountByCategory;
+    }
+
+    @Override
+    public List<ProblemDto> fetchProblemsByGroupId(Long groupId) {
+        return problemFetchService.fetchReviewProblems(groupId);
+    }
+
+    private String mapTagToCategory(String tag){
+        if (tag == null || tag.isBlank()) {
+            return "Unknown";
+        }
+
+        return TAG_TO_CATEGORY.getOrDefault(tag, "Other");
+    }
+    private static final Map<String, String> TAG_TO_CATEGORY = Map.ofEntries(
+            // DP
+            Map.entry("dp", "DP"),
+            Map.entry("dp_tree", "DP"),
+            Map.entry("knapsack", "DP"),
+            Map.entry("bitmask_dp", "DP"),
+            Map.entry("digit_dp", "DP"),
+
+            // Graph
+            Map.entry("graphs", "Graph"),
+            Map.entry("graph_traversal", "Graph"),
+            Map.entry("bfs", "Graph"),
+            Map.entry("dfs", "Graph"),
+            Map.entry("shortest_path", "Graph"),
+            Map.entry("dijkstra", "Graph"),
+            Map.entry("bellman_ford", "Graph"),
+            Map.entry("floyd_warshall", "Graph"),
+            Map.entry("topological_sorting", "Graph"),
+            Map.entry("minimum_spanning_tree", "Graph"),
+            Map.entry("union_find", "Graph/DSU"),
+            Map.entry("flow", "Graph/Flow"),
+            Map.entry("bipartite_matching", "Graph/Matching"),
+            Map.entry("scc", "Graph/SCC"),
+            Map.entry("2_sat", "Graph/2-SAT"),
+
+            // Data Structure
+            Map.entry("data_structures", "DataStructure"),
+            Map.entry("stack", "DataStructure"),
+            Map.entry("queue", "DataStructure"),
+            Map.entry("deque", "DataStructure"),
+            Map.entry("priority_queue", "DataStructure"),
+            Map.entry("segtree", "DataStructure/SegmentTree"),
+            Map.entry("fenwick", "DataStructure/Fenwick"),
+            Map.entry("sparse_table", "DataStructure/SparseTable"),
+            Map.entry("trie", "DataStructure/Trie"),
+            Map.entry("hashing", "DataStructure/Hashing"),
+
+            // Greedy / Implementation / String
+            Map.entry("greedy", "Greedy"),
+            Map.entry("implementation", "Implementation"),
+            Map.entry("string", "String"),
+            Map.entry("kmp", "String"),
+            Map.entry("suffix_array", "String"),
+            Map.entry("lcp", "String"),
+
+            // Math / Geometry
+            Map.entry("math", "Math"),
+            Map.entry("number_theory", "Math"),
+            Map.entry("combinatorics", "Math"),
+            Map.entry("geometry", "Geometry"),
+
+            // Search / Paradigms
+            Map.entry("binary_search", "Search"),
+            Map.entry("parametric_search", "Search"),
+            Map.entry("divide_and_conquer", "Divide&Conquer"),
+            Map.entry("two_pointer", "TwoPointers"),
+            Map.entry("sliding_window", "SlidingWindow"),
+            Map.entry("bruteforcing", "Bruteforce"),
+            Map.entry("backtracking", "Backtracking"),
+            Map.entry("meet_in_the_middle", "MeetInTheMiddle")
+    );
+}

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/ProblemFilterService.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/ProblemFilterService.java
@@ -5,5 +5,5 @@ import com.ssafy.BlueStrongMountain.dto.ProblemFilterRequest;
 import java.util.List;
 
 public interface ProblemFilterService {
-    List<ProblemDto> applyFilters(List<ProblemDto> base, ProblemFilterRequest request);
+    List<ProblemDto> applyFilters(Long groupId, List<ProblemDto> base, ProblemFilterRequest request);
 }

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/ProblemFilterServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/ProblemFilterServiceImpl.java
@@ -31,11 +31,11 @@ public class ProblemFilterServiceImpl implements ProblemFilterService{
 
             effectiveReq = req.withTags(recommendTags);
             //최소 해결자 100명 이상
-            if(req.getMinSolvers() == 0)
+            if(effectiveReq.getMinSolvers() == 0)
                 effectiveReq = effectiveReq.withMinSolvers(100);
             //그룹에서의 해결 문제 평균으로 탐색
-            if(req.getDifficultyFrom() == 0 &&
-                    req.getDifficultyTo() == 35){
+            if(effectiveReq.getDifficultyFrom() == 0 &&
+                    effectiveReq.getDifficultyTo() == 35){
                 int groupLevel = (int) groupAnalysisService.calculateAverageDifficultyByGroupId(groupId);
                 int difficultyFrom = Math.max(groupLevel - 1, 0);
                 int difficultyTo = Math.min(groupLevel + 1, 35);

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/ProblemFilterServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/ProblemFilterServiceImpl.java
@@ -34,10 +34,12 @@ public class ProblemFilterServiceImpl implements ProblemFilterService{
             if(effectiveReq.getMinSolvers() == 0)
                 effectiveReq = effectiveReq.withMinSolvers(100);
             //그룹에서의 해결 문제 평균으로 탐색
-            if(effectiveReq.getDifficultyFrom() == 0 &&
+            if(effectiveReq.getDifficultyFrom() == 1 &&
                     effectiveReq.getDifficultyTo() == 35){
                 int groupLevel = (int) groupAnalysisService.calculateAverageDifficultyByGroupId(groupId);
-                int difficultyFrom = Math.max(groupLevel - 1, 0);
+                groupLevel = Math.max(groupLevel, 1);
+
+                int difficultyFrom = Math.max(groupLevel - 1, 1);
                 int difficultyTo = Math.min(groupLevel + 1, 35);
                 effectiveReq = effectiveReq.withDifficulty(difficultyFrom, difficultyTo);
             }

--- a/src/main/java/com/ssafy/BlueStrongMountain/service/ProblemFilterServiceImpl.java
+++ b/src/main/java/com/ssafy/BlueStrongMountain/service/ProblemFilterServiceImpl.java
@@ -7,34 +7,60 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class ProblemFilterServiceImpl implements ProblemFilterService{
+
+    private final GroupAnalysisService groupAnalysisService;
 
 
     @Override
-    public List<ProblemDto> applyFilters(List<ProblemDto> base, ProblemFilterRequest req) {
+    public List<ProblemDto> applyFilters(Long groupId, List<ProblemDto> base, ProblemFilterRequest req) {
+
+        ProblemFilterRequest effectiveReq = req;
+
+
+        //FIXME random 기능에도 추천 기능 적용되고 있음
+        if((req.getOption() == 2 || req.getOption() == 1) && req.getTags().isEmpty()){
+            //group 분석해서 추천 태그 설정
+            List<String> recommendTags = groupAnalysisService.recommendTagsByGroup(groupId);
+
+            effectiveReq = req.withTags(recommendTags);
+            //최소 해결자 100명 이상
+            if(req.getMinSolvers() == 0)
+                effectiveReq = effectiveReq.withMinSolvers(100);
+            //그룹에서의 해결 문제 평균으로 탐색
+            if(req.getDifficultyFrom() == 0 &&
+                    req.getDifficultyTo() == 35){
+                int groupLevel = (int) groupAnalysisService.calculateAverageDifficultyByGroupId(groupId);
+                int difficultyFrom = Math.max(groupLevel - 1, 0);
+                int difficultyTo = Math.min(groupLevel + 1, 35);
+                effectiveReq = effectiveReq.withDifficulty(difficultyFrom, difficultyTo);
+            }
+        }
+        ProblemFilterRequest finalReq = effectiveReq;
 
         List<ProblemDto> filterRet = base.stream()
-                .filter(p -> filterByProblemIds(req, p))
-                .filter(p -> filterByDifficulty(req, p))
-                .filter(p -> filterByTags(req, p))
-                .filter(p -> filterByMinSolvers(req, p))
+                .filter(p -> filterByProblemIds(finalReq, p))
+                .filter(p -> filterByDifficulty(finalReq, p))
+                .filter(p -> filterByTags(finalReq, p))
+                .filter(p -> filterByMinSolvers(finalReq, p))
                 .toList();
 
-        if(req.getOption() == 1){
+        //FIXME random 기능에도 추천 기능 적용되고 있음
+        if(req.getOption() == 1 || req.getOption() == 2){
             if(filterRet.isEmpty()){
                 return List.of();
             }
             List<ProblemDto> shuffledList = new ArrayList<>(filterRet);
             Collections.shuffle(shuffledList);
 
-            return shuffledList.subList(0, Math.min(5, shuffledList.size()));
-        }
-        if(req.getOption() == 2){
 
-            return new ArrayList<>();
+            return shuffledList.subList(0, Math.min(5, shuffledList.size()));
         }
         return filterRet;
     }


### PR DESCRIPTION
이슈번호: https://github.com/cheonggangsan/BlueStrongMountain_backend/issues/82
---

## ✅ 구현 내용

### 1. 그룹 분석 기반 추천 로직 도입

* `GroupAnalysisService` / `GroupAnalysisServiceImpl` 신규 추가
* 그룹 내 풀이 이력을 기반으로 다음 정보 분석

  * 카테고리별 풀이 태그 수 집계
  * 평균 난이도 계산
* **풀이가 적은 카테고리를 우선 선택**하도록
  `exp(-β * count)` 기반 softmax 확률 샘플링 적용

---

### 2. 추천 결과를 필터 요청에 반영

* `ProblemFilterRequest`를 immutable 객체로 유지하면서

  * `withTags`
  * `withMinSolvers`
  * `withDifficulty`
    메서드 추가
* option=2(추천 모드)이고 태그가 없는 경우:

  * 추천 태그 자동 주입
  * 최소 해결자 수 기본값 설정
  * 그룹 평균 난이도 기준으로 난이도 범위 보정

---

## 🧪 동작 흐름 요약

1. 기본 문제 목록 조회
2. option=2 & 태그 미지정 시

   * 그룹 풀이 데이터 분석
   * 추천 카테고리 선택 (softmax)
   * 카테고리 → 태그 매핑
3. 추천 태그 + 난이도 + 최소 해결자 조건 반영
4. 최종 필터링 수행
5. option에 따라 결과 반환

---

## 💡설계 의도

* 추천 로직은 **완전 랜덤이 아닌 “확률적 다양성 확보”**를 목표로 설계
* 동일 그룹에서 특정 유형 문제만 반복 추천되는 현상 방지
* `ProblemFilterRequest`를 immutable로 유지해
  → 필터 조건 변경 시 부작용 최소화

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 그룹 기반 분석 도구 추가 — 그룹별 태그 추천, 평균 난이도 산출 및 그룹 문제 조회 지원
  * 필터 요청 객체에 체인식 불변 업데이트 메서드 추가로 필터 구성 편의성 향상

* **개선**
  * 필터가 그룹 범위를 반영하도록 변경되어 그룹 최적화된 추천·난이도·해결자 수 보정 적용
  * 일부 필터 옵션에서 결과를 무작위화하고 상한(최대 개수)을 적용해 추천 품질 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->